### PR TITLE
Dedupe addresses obtained from geolocation fulltext

### DIFF
--- a/app/javascript/src/geolocation.js
+++ b/app/javascript/src/geolocation.js
@@ -35,7 +35,21 @@ $(document).ready(function () {
 
                         dropdownObject = [];
 
-                        data.forEach(function (item, i) {
+                        // Deduplikace podle více ID
+                        const dedupedData = [];
+                        for (const elem of data) {
+                            if (
+                              !dedupedData.some(
+                                val =>
+                                  val.okres_kod === elem.okres_kod &&
+                                  val.obec_kod === elem.obec_kod &&
+                                  val.cast_obce_kod === elem.cast_obce_kod
+                              )
+                            )
+                              dedupedData.push(elem);
+                          }
+
+                        dedupedData.forEach(function (item, i) {
                             // Vytvoření objektu s adresním místem
                             var res = GetAddressFormat(item);
 


### PR DESCRIPTION
Some addresses are obtained multiple times from the API but they have the same IDs on multiple levels. 

This PR discards duplicates so that the addresses suggest is more straightforward

Before:
![Screenshot from 2020-03-18 06-23-10](https://user-images.githubusercontent.com/13099178/76928468-e1983380-68e1-11ea-9651-2c579ffd1e9a.png)

Now:
![Screenshot from 2020-03-18 06-23-56](https://user-images.githubusercontent.com/13099178/76928475-e52bba80-68e1-11ea-86b1-ad5d6801c5e7.png)


Resolves #54 