### PR TITLE
Add customized view for lost password page

### DIFF
--- a/app/views/active_admin/devise/passwords/new.html.erb
+++ b/app/views/active_admin/devise/passwords/new.html.erb
@@ -1,0 +1,15 @@
+<div id="login">
+  <%= image_tag asset_path('pomuzemesi.svg'), class: 'centering'  %>
+  <h2><%= title t('active_admin.devise.reset_password.title') %></h2>
+
+  <%= active_admin_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+    f.inputs do
+      f.input :email
+    end
+    f.actions do
+      f.action :submit, label: t('active_admin.devise.reset_password.submit'), button_html: { value: t('active_admin.devise.reset_password.submit') }
+    end
+  end %>
+
+  <%= render partial: "active_admin/devise/shared/links" %>
+</div>


### PR DESCRIPTION
Changed the view for lost password page so it would have consistent look-and-feel as login page and the error messages would be displayed in a better way.

Before
![password_new_before](https://user-images.githubusercontent.com/1512987/77046911-1b416b00-69c4-11ea-9198-dbf14328dd25.png)

After
![password_new_after](https://user-images.githubusercontent.com/1512987/77046930-2399a600-69c4-11ea-83a1-98e082d154c8.png)
