### PR TITLE
add spec tests for sms confirmable concern

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,12 @@ module PomuzemeSi
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    config.i18n.default_locale = :cs
+    config.i18n.available_locales = [
+      :cs,
+      :en
+    ]
+
     config.assets.paths << Rails.root.join('app', 'assets', 'fonts')
 
     config.generators do |g|

--- a/spec/models/sms_confirmable_spec.rb
+++ b/spec/models/sms_confirmable_spec.rb
@@ -1,0 +1,154 @@
+require 'rails_helper'
+
+describe SmsConfirmable do
+  describe '#confirmed?' do
+    subject(:confirmable) { build(:volunteer, confirmed_at: confirmed_at) }
+
+    context 'confirmed_at is not set' do
+      let(:confirmed_at) { nil }
+
+      it { expect(confirmable.confirmed?).to be_falsey }
+    end
+
+    context 'confirmed_at is set' do
+      let(:confirmed_at) { Time.now }
+
+      it { expect(confirmable.confirmed?).to be_truthy }
+    end
+  end
+
+  describe '#confirm_with' do
+    let(:confirmed_at) { nil }
+    let(:sms_confirmation_code) { confirmation_code }
+    let(:confirmation_code) { 'ABCD' }
+    let(:confirmation_valid_to) { 5.minutes.from_now }
+
+    subject(:confirmable) do
+      build(:volunteer,
+            confirmed_at: confirmed_at,
+            confirmation_code: confirmation_code,
+            confirmation_valid_to: confirmation_valid_to)
+    end
+
+    it 'confirms model' do
+      expect do
+        confirmable.confirm_with(sms_confirmation_code)
+      end.to change(confirmable, :confirmed_at).from(nil)
+    end
+
+    context 'is already confirmed' do
+      let(:confirmed_at) { 1.day.ago }
+
+      it 'adds error to confirmable model' do
+        confirmable.confirm_with(sms_confirmation_code)
+        expect(confirmable.errors.messages.values.flatten)
+          .to include('is already confirmed')
+      end
+    end
+
+    context 'given sms code and stored code are nil' do
+      let(:sms_confirmation_code) { nil }
+      let(:confirmation_code) { nil }
+
+      it 'adds error to confirmable model' do
+        confirmable.confirm_with(sms_confirmation_code)
+        expect(confirmable.errors.messages.values.flatten)
+          .to_not include('is not matching')
+      end
+    end
+
+    context 'given sms code does not match stored code' do
+      let(:sms_confirmation_code) { 'ZYXW' }
+
+      it 'adds error to confirmable model' do
+        confirmable.confirm_with(sms_confirmation_code)
+        expect(confirmable.errors.messages.values.flatten)
+          .to include('is not matching')
+      end
+    end
+
+    context 'given no confirmation_valid_to is set' do
+      let(:confirmation_valid_to) { nil }
+
+      it do
+        expect do
+          confirmable.confirm_with(sms_confirmation_code)
+        end.to raise_error(StandardError)
+      end
+    end
+
+    context 'code is expired' do
+      let(:confirmation_valid_to) { 5.minutes.ago }
+
+      it 'adds error to confirmable model' do
+        confirmable.confirm_with(sms_confirmation_code)
+        expect(confirmable.errors.messages.values.flatten)
+          .to include('is expired')
+      end
+    end
+
+  end
+
+  describe '#obtain_confirmation_code' do
+    let(:confirmed_at) { nil }
+    let(:confirmation_code) { nil }
+    let(:confirmation_valid_to) { nil }
+
+    subject(:confirmable) do
+      build(:volunteer,
+            confirmed_at: confirmed_at,
+            confirmation_code: confirmation_code,
+            confirmation_valid_to: confirmation_valid_to)
+    end
+
+    before do
+      allow_any_instance_of(Sms::Provider).to receive(:send_msg)
+    end
+
+    context 'confirmed_at is set' do
+      let(:confirmed_at) { Time.now }
+
+      it 'raises error' do
+        expect do
+          confirmable.obtain_confirmation_code
+        end.to raise_error('Token already generated')
+      end
+    end
+
+   context 'confirmed_at is not set' do
+      before do
+        allow(subject).to receive(:can_obtain_code?).and_return(false)
+      end
+
+      context 'and can obtain confirmation code' do
+        it do
+          expect do
+            confirmable.obtain_confirmation_code
+          end.to raise_error('Token regenerated too early')
+        end
+      end
+    end
+
+    context 'and can obtain confirmation code' do
+      let(:sms_manager) { double(:sms_manager) }
+
+      it 'updates confirmation_code on model' do
+        expect do
+          confirmable.obtain_confirmation_code
+        end.to change(confirmable, :confirmation_code).from(nil)
+      end
+
+      it 'updates confirmation_valid_to on model' do
+        expect do
+          confirmable.obtain_confirmation_code
+        end.to change(confirmable, :confirmation_valid_to).from(nil)
+      end
+
+      it 'sends new SMS' do
+        allow(Sms::Manager).to receive(:new).and_return(sms_manager)
+        expect(sms_manager).to receive(:send_verification_code).once
+        confirmable.obtain_confirmation_code
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,4 +50,5 @@ RSpec.configure do |config|
   I18n.locale = :en
 
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
 end


### PR DESCRIPTION
The SmsConfirmable concern was undertested. Here they are.
For `#confirm_with` the case of having confirmation codes as nil in the db and as parameter is not handled in the method, so the tests only documents what is happening right now.

I couldn't get behind the logic for the repeat break and the validation times in time. Maybe somebody who knows how this works can restructure the methods a bit to have this clearer.