### PR TITLE
add vendorfile

### DIFF
--- a/Vendorfile
+++ b/Vendorfile
@@ -1,0 +1,3 @@
+# List urls
+https://vesuvius.herokuapp.com/libraries/geos-3.8.1-heroku.tar.gz
+https://vesuvius.herokuapp.com/libraries/proj-5.2.0-heroku.tar.gz


### PR DESCRIPTION
According to `rgeo` docs, this PR add Vendorfile referencing for heroku's rgeo and proj binaries

https://github.com/rgeo/rgeo/wiki/Enable-GEOS-and-Proj4-on-Heroku