### PR TITLE
load default mailer host url from ENV

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,6 +67,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "pomuzeme_si_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { host: ENV['MAILER_HOST'] }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
This PR modifies `production.rb` to load `ActionMailer`'s `default_url_options` from `ENV` variable

Closes https://github.com/Applifting/pomuzeme.si/issues/99