### PR TITLE
do not propagate addressable error into address error messages

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -34,6 +34,10 @@ class Address < ApplicationRecord
     [street_number, street, city, city_part, postal_code].compact.join ', '
   end
 
+  def only_address_errors?
+    errors.keys.map(&:to_s).none? { |key| key.start_with? 'addressable' }
+  end
+
   private
 
   def initialize_defaults

--- a/app/views/volunteer/register_error.js.erb
+++ b/app/views/volunteer/register_error.js.erb
@@ -10,6 +10,6 @@ registrationErrors.empty();
   registrationErrors.append('<li><%= message %></li>')
 <% end %>
 
-<% if address.errors.any? %>
+<% if address.only_address_errors? %>
   registrationErrors.append('<li><%= I18n.t('activerecord.errors.models.address.base.inaccurate_address') %></li>')
 <% end %>

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -193,7 +193,7 @@ cs:
               improbable_phone: není správně
         address:
           base:
-            inaccurate_address: Nepřesná adresa. Prosíme vyberte celou adresu i s číslem popisným
+            inaccurate_address: Nepřesná adresa. Prosíme vyberte adresu z našeptávače.
     messages:
       sms_resended: Váš kód byl změněn a SMS je na cestě.
 


### PR DESCRIPTION
If there is error on `addressable`, it is propageted into `Address` model instance. Thus message about invalid address is displayed on landing page, even though it is not relevant.