### PR TITLE
dummy fix migration

### DIFF
--- a/app/admin/volunteers.rb
+++ b/app/admin/volunteers.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register Volunteer do
   permit_params :description, :first_name, :last_name, :phone, :email
 
   scope :all, default: true do |scope|
-    scope.available_for(current_user.organisation_group.id)
+    current_user.admin? ?  scope : scope.available_for(current_user.organisation_group.id)
   end
   scope :unconfirmed, if: -> { current_user.admin? }
   scope :confirmed, if: -> { current_user.admin? }

--- a/db/migrate/20200323074614_lookup_invalid_coordinates.rb
+++ b/db/migrate/20200323074614_lookup_invalid_coordinates.rb
@@ -3,7 +3,7 @@ class LookupInvalidCoordinates < ActiveRecord::Migration[6.0]
     reversible do |dir|
       dir.up do
         ActiveRecord::Base.transaction do
-          invalid_addresses.each { |address| fix_coordinate address }
+          invalid_addresses.each { |address| fix_coordinate(address) if address.addressable.present? }
         end
       end
     end


### PR DESCRIPTION
There is problem in models dependencies, where we propably does not propagate destroy of addressable to `Address`. So skip invalid data in migration now and fix it later ( https://github.com/Applifting/pomuzeme.si/issues/127 )

Also fixes scope when superadmin joins volunteers