### PR TITLE
modify volunteer request assignment

### DIFF
--- a/app/admin/volunteers.rb
+++ b/app/admin/volunteers.rb
@@ -53,6 +53,8 @@ ActiveAdmin.register Volunteer do
 
     if scoped_request
       para I18n.t('active_admin.batch_actions.assign_request.title', request: scoped_request.title)
+      para I18n.t('active_admin.batch_actions.assign_request.description'), class: :small
+      para
       selectable_column
     end
     id_column

--- a/app/admin/volunteers.rb
+++ b/app/admin/volunteers.rb
@@ -32,7 +32,7 @@ ActiveAdmin.register Volunteer do
   config.batch_actions = true
   # Form args has to be inside lambda due to calling of current_user
 
-  batch_action :assign_request do |ids|
+  batch_action :assign_request, confirm: I18n.t('active_admin.batch_actions.assign_request.confirmation') do |ids|
     request = referer_request
     Admin::Requests::VolunteerAssigner.new(current_user, request, Volunteer.where(id: ids)).perform
     redirect_to admin_organisation_request_path request.id
@@ -52,7 +52,7 @@ ActiveAdmin.register Volunteer do
     javascript_for(*location_autocomplete(callback: 'InitFilterAutocomplete'))
 
     if scoped_request
-      para "Vybíráte dobrovolníky pro poptávku: #{scoped_request.title}"
+      para I18n.t('active_admin.batch_actions.assign_request.title', request: scoped_request.title)
       selectable_column
     end
     id_column

--- a/app/helpers/active_admin/volunteers_helper.rb
+++ b/app/helpers/active_admin/volunteers_helper.rb
@@ -1,0 +1,14 @@
+module ActiveAdmin
+  module VolunteersHelper
+    def scoped_request
+      return @scoped_request if defined? @scoped_request
+
+      @scoped_request = Request.find_by id: params[:request_id]
+    end
+
+    def referer_request
+      referer_params = Rack::Utils.parse_nested_query(URI.parse(request.referer).query)
+      Request.find referer_params['request_id']
+    end
+  end
+end

--- a/app/views/admin/organisation_requests/_volunteers.html.arb
+++ b/app/views/admin/organisation_requests/_volunteers.html.arb
@@ -2,7 +2,7 @@
 
 div class: 'title h4' do
   span 'Dobrovolníci'
-  span link_to('', new_admin_organisation_request_requested_volunteer_path(organisation_request_id: resource.id), class: 'action add') if can?(:manage, Request)
+  span link_to('', admin_volunteers_path(params: {request_id: resource.id}), class: 'action add') if can?(:manage, Request)
 end
 
 table_for resource.requested_volunteers.includes(:volunteer).order(:state).map(&:decorate) do

--- a/config/locales/active_admin.cs.yml
+++ b/config/locales/active_admin.cs.yml
@@ -76,6 +76,7 @@ cs:
         assign_request: 'Přiřadit požadavek'
       assign_request:
         title: "Vybíráte dobrovolníky pro poptávku: %{request}"
+        description: seznam neobsahuje dobrovolníky, kteří jsou již v poptávce zařazeni
         confirmation: "Opravdu chcete přidat dobrovolníky do poptávky?"
     comments:
       resource_type: "Typ zdroje"

--- a/config/locales/active_admin.cs.yml
+++ b/config/locales/active_admin.cs.yml
@@ -74,6 +74,9 @@ cs:
       labels:
         destroy: "Vymazat"
         assign_request: 'Přiřadit požadavek'
+      assign_request:
+        title: "Vybíráte dobrovolníky pro poptávku: %{request}"
+        confirmation: "Opravdu chcete přidat dobrovolníky do poptávky?"
     comments:
       resource_type: "Typ zdroje"
       author_type: "Typ autora"


### PR DESCRIPTION
Modify batch action on volunteers page
- display only if `params` includes valid `request_id`
- assign volunteers automatically without selection request
- if `request_id` is present, show only unassigned volunteers to the request

