### PR TITLE
Fix/destroy dependent records

### DIFF
--- a/app/models/abilities/coordinator.rb
+++ b/app/models/abilities/coordinator.rb
@@ -9,7 +9,6 @@ module Abilities
       can %i[read download], [Volunteer, VolunteerDecorator], id: Volunteer.available_for(user.organisation_group.id).pluck(:id)
       cannot %i[read], Volunteer, confirmed_at: nil
 
-      # TODO: Tom: I doubt this works, abilitites need automated tests
       can %i[read], [Group], id: user.coordinating_groups.pluck(:id)
 
       can :manage, Label, group_id: user.coordinating_groups.pluck(:id)
@@ -24,15 +23,17 @@ module Abilities
       cannot :create, Recruitment
 
       can :create, [GroupVolunteer]
-      can :manage, [GroupVolunteer, GroupVolunteerDecorator], id: user.group_volunteers.pluck(:id)
-      cannot :destroy, [GroupVolunteer, GroupVolunteerDecorator]
+      can %i[read create update], [GroupVolunteer, GroupVolunteerDecorator], id: user.group_volunteers.pluck(:id)
     end
 
     def can_manage_requests(user)
       can :create, Request
-      can %i[index read], [Request, RequestDecorator], organisation_id: Organisation.user_group_organisations(user).pluck(:id)
-      can :manage, [Request, RequestDecorator], organisation_id: user.coordinating_organisations.pluck(:id)
 
+      # read-only access to requests within organisation group
+      can %i[index read], [Request, RequestDecorator], organisation_id: Organisation.user_group_organisations(user).pluck(:id)
+
+      # full access to requests in user's organisations
+      can :manage, [Request, RequestDecorator], organisation_id: user.coordinating_organisations.pluck(:id)
       can :manage, [RequestedVolunteer, RequestedVolunteerDecorator], request: { organisation_id: Organisation.user_group_organisations(user).pluck(:id) }
     end
   end

--- a/app/models/abilities/super_admin.rb
+++ b/app/models/abilities/super_admin.rb
@@ -2,8 +2,6 @@ module Abilities
   module SuperAdmin
     def add_super_admin_ability(user)
       can :manage, :all
-      cannot :destroy, :all
-      can :destroy, [Volunteer, VolunteerDecorator]
     end
   end
 end

--- a/app/models/abilities/super_admin.rb
+++ b/app/models/abilities/super_admin.rb
@@ -2,6 +2,8 @@ module Abilities
   module SuperAdmin
     def add_super_admin_ability(user)
       can :manage, :all
+      cannot :destroy, :all
+      can :destroy, [Volunteer, VolunteerDecorator]
     end
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,9 +1,9 @@
 class Group < ApplicationRecord
   # Associations
-  has_many :labels
-  has_many :organisation_groups
+  has_many :labels, dependent: :destroy
+  has_many :organisation_groups, dependent: :destroy
   has_many :organisations, through: :organisation_groups
-  has_many :group_volunteers
+  has_many :group_volunteers, dependent: :destroy
   has_many :volunteers, through: :group_volunteers
 
   # Validations

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,7 +1,7 @@
 class Label < ApplicationRecord
   # Associations
   belongs_to :group
-  has_many :volunteer_labels
+  has_many :volunteer_labels, dependent: :destroy
 
   # Validations
   validates :name, uniqueness: { scope: :group_id }

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -9,9 +9,9 @@ class Organisation < ApplicationRecord
            class_name: :User,
            through: :roles,
            source: :users
-  has_many :organisation_groups
+  has_many :organisation_groups, dependent: :destroy
   has_many :groups, through: :organisation_groups
-  has_many :requests
+  has_many :requests, dependent: :destroy
 
   # Validations
   validates :name, presence: true

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -10,7 +10,7 @@ class Request < ApplicationRecord
   belongs_to :closer, class_name: 'User', foreign_key: :closed_by_id, optional: true
   belongs_to :coordinator, class_name: 'User', foreign_key: :coordinator_id, optional: true
   belongs_to :organisation
-  has_many :requested_volunteers
+  has_many :requested_volunteers, dependent: :destroy
   has_many :volunteers, through: :requested_volunteers
 
   # Validations

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -7,12 +7,12 @@ class Volunteer < ApplicationRecord
   NOT_RECRUITED_BY_CONDITIONS = 'group_volunteers.id is null OR (group_volunteers.is_exclusive = false and group_volunteers.group_id != %{group_id})'.freeze
 
   # Associations
-  has_many :addresses, as: :addressable
-  has_many :group_volunteers, dependent: :delete_all
+  has_many :addresses, as: :addressable, dependent: :destroy
+  has_many :group_volunteers, dependent: :destroy
   has_many :groups, through: :group_volunteers
-  has_many :volunteer_labels, dependent: :delete_all
+  has_many :volunteer_labels, dependent: :destroy
   has_many :labels, through: :volunteer_labels
-  has_many :requested_volunteers, dependent: :delete_all
+  has_many :requested_volunteers, dependent: :destroy
   has_many :requests, through: :requested_volunteers
 
   # normalize phone format and add default czech prefix if missings


### PR DESCRIPTION
- propagate destroy actions to associated records
- User with `super_admin` role can destroy only `Volunteer` records, nothing more