### PR TITLE
allow request to block volunteer

### DIFF
--- a/app/admin/requests.rb
+++ b/app/admin/requests.rb
@@ -7,7 +7,7 @@ ActiveAdmin.register Request, as: 'OrganisationRequest' do
   menu priority: 2
 
   permit_params :closed_note, :coordinator_id, :created_by_id, :fullfillment_date, :organisation_id,
-                :required_volunteer_count, :state, :subscriber, :subscriber_phone, :text,
+                :required_volunteer_count, :state, :subscriber, :subscriber_phone, :text, :block_volunteer_until,
                 address_attributes: %i[street_number street city city_part postal_code country_code
                                        latitude longitude geo_entry_id]
 
@@ -58,6 +58,7 @@ ActiveAdmin.register Request, as: 'OrganisationRequest' do
           row :id
           row :organisation
           row :required_volunteer_count
+          row :block_volunteer_until
           row :coordinator
           row :state
           row :state_last_updated_at
@@ -113,7 +114,11 @@ ActiveAdmin.register Request, as: 'OrganisationRequest' do
 
     f.inputs 'Koordinace' do
       f.input :state if resource.persisted?
-      f.input :organisation, as: :select, collection: Organisation.user_group_organisations(current_user)
+      f.input :organisation, as: :select,
+                             collection: Organisation.where(id: current_user.coordinating_organisations.pluck(:id)),
+                             include_blank: false
+      f.input :fullfillment_date, as: :datetime_picker
+      f.input :block_volunteer_until, as: :datetime_picker
       f.input :coordinator_id, as: :select, collection: current_user.organisation_colleagues
       f.input :closed_note, as: :text if resource.persisted?
       f.input :created_by_id, as: :hidden, input_html: { value: current_user.id }

--- a/app/admin/volunteers.rb
+++ b/app/admin/volunteers.rb
@@ -46,7 +46,7 @@ ActiveAdmin.register Volunteer do
     include ActiveAdmin::VolunteersHelper
 
     def scoped_collection
-      scoped_request ? super.where.not(id: Volunteer.assigned_to_request(scoped_request.id)) : super
+      scoped_request ? super.not_blocked.where.not(id: Volunteer.assigned_to_request(scoped_request.id)) : super
     end
   end
 

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -34,6 +34,8 @@ class Volunteer < ApplicationRecord
   scope :verified_by, ->(group_id) { left_joins(:group_volunteers).where(group_volunteers: { group_id: group_id, recruitment_status: 3 }) }
   scope :not_recruited_by, ->(group_id) { left_joins(:group_volunteers).where(format(NOT_RECRUITED_BY_CONDITIONS, group_id: group_id)) }
   scope :assigned_to_request, ->(request_id) { left_joins(:requested_volunteers).where(requested_volunteers: { request_id: request_id }) }
+  scope :blocked, -> { left_joins(:requests).where(requested_volunteers: { state: :accepted }, requests: { block_volunteer_until: Time.now.. }) }
+  scope :not_blocked, -> { where.not(id: blocked) }
 
   attr_accessor :address_search_input
 

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -149,6 +149,7 @@ cs:
         full_address: Adresa
         update_address: Nová adresa
         fullfillment_date: Požadované datum vyřízení
+        block_volunteer_until: Blokace dobrovolníka do
         organisation: Organizace
         required_volunteer_count: Požadovaný počet dobrovolníků
         accepted_volunteers_count: Potvrzení / požadovaní dobrovolníci

--- a/db/migrate/20200324180605_add_block_volunteer_until_to_request.rb
+++ b/db/migrate/20200324180605_add_block_volunteer_until_to_request.rb
@@ -1,0 +1,5 @@
+class AddBlockVolunteerUntilToRequest < ActiveRecord::Migration[6.0]
+  def change
+    add_column :requests, :block_volunteer_until, :datetime
+  end
+end


### PR DESCRIPTION
- add scope `blocked` and `not_blocked` to volunteers. Not sticking with issue spec as `available` was a bit confusing to me according to `available~_for` scope
- do not display blocked volunteers at index page where coordinator chooses volunteers for request 

Closes https://github.com/Applifting/pomuzeme.si/issues/150