### PR TITLE
fix ransack scope combination

### DIFF
--- a/app/admin/requested_volunteers.rb
+++ b/app/admin/requested_volunteers.rb
@@ -2,7 +2,7 @@
 
 ActiveAdmin.register RequestedVolunteer do
   decorate_with RequestedVolunteerDecorator
-  belongs_to :organisation_request
+  belongs_to :organisation_request, parent_class: Request
   permit_params :request_id, :volunteer_id, :state
 
   controller do

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -66,10 +66,10 @@ class Volunteer < ApplicationRecord
   end
 
   def self.has_labels(*label_ids)
-    joins(:volunteer_labels)
-        .where('volunteer_labels' => { label_id: label_ids })
-        .group(:id)
-        .having("count(*) >= #{label_ids.count}")
+    where(id: Volunteer.unscoped.joins(:volunteer_labels)
+                                .where('volunteer_labels' => { label_id: label_ids })
+                                .group(:id)
+                                .having("count(*) >= #{label_ids.count}").select(:id))
   end
 
   def self.search_nearby(encoded_location)


### PR DESCRIPTION
When combining two ransack scopes (e.g. address filter and volunteer label filter), there was an error cause by automatically misplaced `order` statement.

```
SELECT COUNT(*) FROM "volunteers"
    INNER JOIN "addresses" ON "addresses"."addressable_id" = "volunteers"."id" AND "addresses"."addressable_type" = 'Volunteer'
    LEFT OUTER JOIN "group_volunteers" ON "group_volunteers"."volunteer_id" = "volunteers"."id"
    CROSS JOIN (SELECT ST_SetSRID(ST_MakePoint(14.5053859, 50.1382451), 4326)::geography AS ref_geom) AS r
WHERE "volunteers"."id" IN (SELECT "volunteers"."id" FROM "volunteers"
    INNER JOIN "volunteer_labels" ON "volunteer_labels"."volunteer_id" = "volunteers"."id"
WHERE "volunteer_labels"."label_id" = 1 GROUP BY "volunteers"."id"
HAVING (count(*) >= 1) ORDER BY "distance_meters" asc) <<-- Order by is nested in other query and causes SQL exceptions
```