### PR TITLE
allow admin to export users email/phone

### DIFF
--- a/app/admin/volunteers.rb
+++ b/app/admin/volunteers.rb
@@ -61,10 +61,10 @@ ActiveAdmin.register Volunteer do
     id_column
     column :full_name
     column :phone do |resource|
-      resource.show_contact_details?(params) ? resource.phone : 'v detailu'
+      resource.show_contact_details?(current_user, params) ? resource.phone : 'v detailu'
     end
     column :email do |resource|
-      resource.show_contact_details?(params) ? resource.email : 'v detailu'
+      resource.show_contact_details?(current_user, params) ? resource.email : 'v detailu'
     end
     column :address
     if params[:q] && params[:q][:search_nearby]
@@ -114,10 +114,10 @@ ActiveAdmin.register Volunteer do
     column :first_name
     column :last_name
     column :phone do |resource|
-      resource.show_contact_details?(params) ? resource.phone : 'v detailu'
+      resource.show_contact_details?(current_user, params) ? resource.phone : 'v detailu'
     end
     column :email do |resource|
-      resource.show_contact_details?(params) ? resource.email : 'v detailu'
+      resource.show_contact_details?(current_user, params) ? resource.email : 'v detailu'
     end
     column :street
     column :city

--- a/app/decorators/volunteer_decorator.rb
+++ b/app/decorators/volunteer_decorator.rb
@@ -19,8 +19,8 @@ class VolunteerDecorator < ApplicationDecorator
     end
   end
 
-  def show_contact_details?(params)
-    params['scope'] == 'volunteer_verified' || params['scope'].nil?
+  def show_contact_details?(user, params)
+    user.admin? || params['scope'] == 'volunteer_verified' || params['scope'].nil?
   end
 
   def full_name


### PR DESCRIPTION
Allow user with role `super_admin` to export CSV with contact information.

As side efect, `super_admin` can see personal information also in volunteers listing.

closes https://github.com/Applifting/pomuzeme.si/issues/217