### PR TITLE
change datetime picker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,7 @@ gem 'active_admin-humanized_enum'
 gem 'activeadmin'
 gem 'arctic_admin'
 gem 'draper'
+gem 'active_admin_datetimepicker'
 
 # geocoding
 gem 'geocoder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,11 +40,15 @@ GEM
     active_admin-humanized_enum (0.1.1)
       active_record-humanized_enum
       activeadmin (>= 1.0.0.pre1)
+    active_admin_datetimepicker (0.7.4)
+      activeadmin (>= 1.1, < 3.a)
+      coffee-rails
+      xdan-datetimepicker-rails (~> 2.5.4)
     active_record-humanized_enum (0.1.2)
       activesupport
       i18n
       railties
-    activeadmin (2.6.1)
+    activeadmin (2.7.0)
       arbre (~> 1.2, >= 1.2.1)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)
@@ -103,7 +107,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.1)
     cancancan (3.1.0)
-    capybara (3.31.0)
+    capybara (3.32.1)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -116,6 +120,13 @@ GEM
       httparty
       rails (>= 5.0, < 6.1.0)
     coderay (1.1.2)
+    coffee-rails (5.0.0)
+      coffee-script (>= 2.2.0)
+      railties (>= 5.2.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
     crass (1.0.6)
@@ -126,22 +137,23 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-i18n (1.9.0)
+    devise-i18n (1.9.1)
       devise (>= 4.7.1)
     diff-lcs (1.3)
-    draper (4.0.0)
+    draper (4.0.1)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
       activemodel-serializers-xml (>= 1.0)
       activesupport (>= 5.0)
       request_store (>= 1.0)
     erubi (1.9.0)
-    factory_bot (5.1.1)
+    execjs (2.7.0)
+    factory_bot (5.1.2)
       activesupport (>= 4.2.0)
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
-    faraday (1.0.0)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffaker (2.14.0)
     ffi (1.12.2)
@@ -190,7 +202,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -215,7 +227,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     parallel (1.19.1)
-    parser (2.7.0.5)
+    parser (2.7.1.0)
       ast (~> 2.4.0)
     pg (1.2.3)
     phony (2.18.12)
@@ -229,7 +241,7 @@ GEM
       method_source (~> 1.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (4.0.3)
+    public_suffix (4.0.4)
     puma (4.3.3)
       nio4r (~> 2.0)
     rack (2.2.2)
@@ -281,7 +293,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    recaptcha (5.4.1)
+    recaptcha (5.5.0)
       json
     redis (4.1.3)
     regexp_parser (1.7.0)
@@ -313,17 +325,17 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    rubocop (0.80.1)
+    rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
       rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    ruby_http_client (3.3.0)
+    ruby_http_client (3.5.0)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -338,8 +350,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sendgrid-ruby (6.0.0)
-      ruby_http_client (~> 3.3.0)
+    sendgrid-ruby (6.1.3)
+      ruby_http_client (~> 3.4)
     sentry-raven (3.0.0)
       faraday (>= 1.0)
     shoulda-matchers (4.3.0)
@@ -368,9 +380,9 @@ GEM
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    unicode-display_width (1.6.1)
+    unicode-display_width (1.7.0)
     validates_zipcode (0.2.4)
       activemodel (>= 3.2.0)
     warden (1.2.8)
@@ -391,6 +403,9 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    xdan-datetimepicker-rails (2.5.4)
+      jquery-rails
+      rails (>= 3.2.16)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.3.0)
@@ -400,6 +415,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_admin-humanized_enum
+  active_admin_datetimepicker
   activeadmin
   activerecord-postgis-adapter
   arctic_admin

--- a/app/admin/requests.rb
+++ b/app/admin/requests.rb
@@ -125,7 +125,7 @@ ActiveAdmin.register Request, as: 'OrganisationRequest' do
     f.inputs 'Poptávka služby' do
       f.input :text, as: :text, hint: 'Tento popis dostane dobrovolník do aplikace / SMS'
       f.input :required_volunteer_count, input_html: { value: object.required_volunteer_count.nil? ? 1 : resource.required_volunteer_count }
-      f.input :fullfillment_date, as: :datetime_picker
+      f.input :fullfillment_date, as: :date_time_picker, input_html: { autocomplete: 'off' }
     end
 
     f.inputs 'Údaje příjemce' do
@@ -157,7 +157,7 @@ ActiveAdmin.register Request, as: 'OrganisationRequest' do
       f.input :organisation, as: :select,
                              collection: organisations,
                              include_blank: false
-      f.input :block_volunteer_until, as: :datetime_picker
+      f.input :block_volunteer_until, as: :date_time_picker, input_html: { autocomplete: 'off' }
       f.input :coordinator_id, as: :select, collection: current_user.organisation_colleagues
       f.input :closed_note, as: :text if resource.persisted?
       f.input :created_by_id, as: :hidden, input_html: { value: current_user.id }

--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -2,6 +2,7 @@
 //= require modal
 //= require geocomplete
 //= require best_in_place
+//= require active_admin_datetimepicker
 
 $(document).ready(function () {
   $.ajaxSetup({

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -7,11 +7,11 @@
 // For example, to change the sidebar width:
 // $sidebar-width: 242px;
 
-
 // Active Admin's got SASS!
 @import "active_admin/mixins";
 @import "arctic_admin/base";
 @import "admin/*";
+@import "active_admin_datetimepicker";
 
 
 // Overriding any non-variable SASS must be done after the fact.

--- a/app/assets/stylesheets/admin/date_time_picker_base.scss
+++ b/app/assets/stylesheets/admin/date_time_picker_base.scss
@@ -1,0 +1,7 @@
+// Some constants picked from active_admin/forms
+
+$sidebar-inner-content-width: $sidebar-width - ($section-padding * 2);
+$filter-field-seperator-width: 12px;
+$side-by-side-filter-input-width: ($sidebar-inner-content-width / 2) - ($text-input-horizontal-padding * 2) - $filter-field-seperator-width;
+$side-by-side-filter-select-width: ($sidebar-inner-content-width / 2) - $filter-field-seperator-width;
+$date-range-filter-input-width: ($sidebar-inner-content-width / 2) - ($filter-field-seperator-width / 2);

--- a/app/assets/stylesheets/admin/form.scss
+++ b/app/assets/stylesheets/admin/form.scss
@@ -1,4 +1,4 @@
-.datetime_picker input {
+.date_time_picker input {
   width: 280px !important;
 }
 


### PR DESCRIPTION
Replacing Formtastics `datetime_picker` component with https://github.com/activeadmin-plugins/active_admin_datetimepicker

Now user can easily select time part of datetime.

![image](https://user-images.githubusercontent.com/1984961/78560121-cc922e80-7815-11ea-942b-9fb8ee57a07d.png)

Unfortuantelly it seems that approaches mentioned in wiki are not satisfying our needs (https://github.com/activeadmin/activeadmin/wiki/combine-datetime-picker-with-activeadmin)

Closes https://github.com/Applifting/pomuzeme.si/issues/196