### PR TITLE
implement caching

### DIFF
--- a/app/admin/addresses.rb
+++ b/app/admin/addresses.rb
@@ -28,7 +28,7 @@ ActiveAdmin.register Address do
       column :distance, sortable: 'distance_meters', &:distance_in_km
     end
 
-    if current_user.admin?
+    if current_user.cached_admin?
       column :created_at
       column :updated_at
     end
@@ -79,7 +79,7 @@ ActiveAdmin.register Address do
       f.input :longitude, as: :hidden
       f.input :geo_entry_id, as: :hidden
       custom_input :redirect_to, type: :hidden, value: request.referrer
-      if current_user.admin?
+      if current_user.cached_admin?
         f.inputs 'Super admin' do
           f.input :addressable_type
           f.input :addressable_id

--- a/app/admin/data_import.rb
+++ b/app/admin/data_import.rb
@@ -21,7 +21,7 @@ ActiveAdmin.register_page 'Import Data' do
   end
 
   content do
-    managable_groups = current_user.admin? ? Group.all : current_user.coordinating_groups
+    managable_groups = current_user.cached_admin? ? Group.all : current_user.coordinating_groups
 
     tabs do
       tab 'Import' do

--- a/app/admin/organisations.rb
+++ b/app/admin/organisations.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register Organisation do
     column :name
     column :abbreviation
     column :business_id_number
-    if current_user.admin?
+    if current_user.cached_admin?
       column :created_at
       column :updated_at
     end

--- a/app/admin/recruitments.rb
+++ b/app/admin/recruitments.rb
@@ -26,10 +26,10 @@ ActiveAdmin.register Recruitment do
     column :is_exclusive
     column :coordinator
     column :comments
-    column(:group) if current_user.admin?
+    column(:group) if current_user.cached_admin?
     column :created_at
     column :updated_at
 
-    actions if current_user.admin?
+    actions if current_user.cached_admin?
   end
 end

--- a/app/admin/requests.rb
+++ b/app/admin/requests.rb
@@ -20,7 +20,7 @@ ActiveAdmin.register Request, as: 'OrganisationRequest' do
 
   # Scopes
   # Experimental feature
-  scope :unread_msgs, default: true, if: -> { current_user.admin? } do |scope|
+  scope :unread_msgs, default: true, if: -> { current_user.cached_admin? } do |scope|
     scope.not_closed.has_unread_messages
   end
   scope :request_in_preparation, default: true do |scope|
@@ -41,7 +41,7 @@ ActiveAdmin.register Request, as: 'OrganisationRequest' do
   # Controller
   controller do
     def scoped_collection
-      super.includes(:address)
+      super.includes(:address, :coordinator, :organisation)
     end
   end
 
@@ -63,7 +63,7 @@ ActiveAdmin.register Request, as: 'OrganisationRequest' do
     column :fullfillment_date
     column :coordinator
     column :state_last_updated_at
-    column :organisation if current_user.admin?
+    column :organisation if current_user.cached_admin?
     actions
   end
 
@@ -154,7 +154,7 @@ ActiveAdmin.register Request, as: 'OrganisationRequest' do
     end
 
     f.inputs 'Koordinace' do
-      organisations = current_user.admin? ? Organisation.all : Organisation.user_group_organisations(current_user)
+      organisations = current_user.cached_admin? ? Organisation.all : Organisation.user_group_organisations(current_user)
 
       f.input :state if resource.persisted?
       f.input :organisation, as: :select,

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -41,7 +41,7 @@ ActiveAdmin.register User do
     column :first_name
     column :last_name
     column :email
-    if current_user.admin?
+    if current_user.cached_admin?
       column :created_at
       column :updated_at
     end

--- a/app/admin/volunteers.rb
+++ b/app/admin/volunteers.rb
@@ -11,10 +11,10 @@ ActiveAdmin.register Volunteer do
   end
   # scope
   scope :volunteer_all, default: true do |scope|
-    current_user.admin? ? scope : scope.available_for(current_user.organisation_group.id)
+    current_user.cached_admin? ? scope : scope.available_for(current_user.organisation_group.id)
   end
-  scope :unconfirmed, if: -> { current_user.admin? }
-  scope :confirmed, if: -> { current_user.admin? }
+  scope :unconfirmed, if: -> { current_user.cached_admin? }
+  scope :confirmed, if: -> { current_user.cached_admin? }
 
   # Filters
   filter :full_name_cont, label: 'Jméno / příjmení'
@@ -75,7 +75,7 @@ ActiveAdmin.register Volunteer do
         resource.address.distance_in_km(resource.distance_meters)
       end
     end
-    column :confirmed? if current_user.admin?
+    column :confirmed? if current_user.cached_admin?
     actions
   end
 

--- a/app/models/abilities/coordinator.rb
+++ b/app/models/abilities/coordinator.rb
@@ -2,21 +2,21 @@ module Abilities
   module Coordinator
     def add_coordinator_ability(user)
       can :read, ActiveAdmin::Page, name: 'Dashboard'
-      can %i[index read], [Organisation, OrganisationDecorator], id: Organisation.user_group_organisations(user).pluck(:id)
-      can :update, [Organisation, OrganisationDecorator], id: user.coordinating_organisations.pluck(:id)
-      can %i[read], [User, UserDecorator], id: user.coordinators_in_organisations.pluck(:id)
+      can %i[index read], [Organisation, OrganisationDecorator], id: user.cache_output(:user_group_organisations) { Organisation.user_group_organisations(user).pluck(:id) }
+      can :update, [Organisation, OrganisationDecorator], id: user.cache_output(:coordinating_organisations) { user.coordinating_organisation_ids }
+      can %i[read], [User, UserDecorator], id: user.cache_output(:coordinators_in_organisations) { user.coordinators_in_organisations.pluck(:id) }
 
-      can %i[read download], [Volunteer, VolunteerDecorator], id: Volunteer.available_for(user.organisation_group.id).pluck(:id)
-      can :manage, [Volunteer, VolunteerDecorator], id: Volunteer.exclusive_for(user.organisation_group.id).pluck(:id)
+      can %i[read download], [Volunteer, VolunteerDecorator], id: Volunteer.available_for(user.cached_organisation_group.id).pluck(:id)
+      can :manage, [Volunteer, VolunteerDecorator], id: Volunteer.exclusive_for(user.cached_organisation_group.id).pluck(:id)
       cannot %i[read], Volunteer, confirmed_at: nil
 
       can :update, [Address, AddressDecorator], Address.all do |address|
         can? :manage, address.addressable
       end
 
-      can %i[read], [Group], id: user.coordinating_groups.pluck(:id)
+      can %i[read], [Group], id: user.cache_output(:coordinating_groups) { user.coordinating_groups.pluck(:id) }
 
-      can :manage, Label, group_id: user.coordinating_groups.pluck(:id)
+      can :manage, Label, group_id: user.cache_output(:coordinating_groups) { user.coordinating_groups.pluck(:id) }
       can :manage, VolunteerLabel
 
       can_manage_requests user
@@ -37,11 +37,11 @@ module Abilities
       can :create, Request
 
       # read-only access to requests within organisation group
-      can %i[index read], [Request, RequestDecorator], organisation_id: Organisation.user_group_organisations(user).pluck(:id)
+      can %i[index read], [Request, RequestDecorator], organisation_id: user.cache_output(:user_group_organisations) { Organisation.user_group_organisations(user).pluck(:id) }
 
       # full access to requests in user's organisations
-      can :manage, [Request, RequestDecorator], organisation_id: user.coordinating_organisations.pluck(:id)
-      can :manage, [RequestedVolunteer, RequestedVolunteerDecorator], request: { organisation_id: Organisation.user_group_organisations(user).pluck(:id) }
+      can :manage, [Request, RequestDecorator], organisation_id: user.cache_output(:coordinating_organisations) { user.coordinating_organisation_ids }
+      can :manage, [RequestedVolunteer, RequestedVolunteerDecorator], request: { organisation_id: user.cache_output(:user_group_organisations) { Organisation.user_group_organisations(user).pluck(:id) } }
 
       # access to ActiveAdmin::Comment
       can %i[index read], ActiveAdmin::Comment, resource_type: 'Request', resource_id: user.coordinator_organisation_requests.pluck(:id)

--- a/app/models/abilities/coordinator.rb
+++ b/app/models/abilities/coordinator.rb
@@ -4,10 +4,10 @@ module Abilities
       can :read, ActiveAdmin::Page, name: 'Dashboard'
       can %i[index read], [Organisation, OrganisationDecorator], id: user.cache_output(:user_group_organisations) { Organisation.user_group_organisations(user).pluck(:id) }
       can :update, [Organisation, OrganisationDecorator], id: user.cache_output(:coordinating_organisations) { user.coordinating_organisation_ids }
-      can %i[read], [User, UserDecorator], id: user.cache_output(:coordinators_in_organisations) { user.coordinators_in_organisations.pluck(:id) }
+      can %i[read], [User, UserDecorator], id: user.cache_output(:group_coordinators) { user.group_coordinators.pluck(:id) }
 
-      can %i[read download], [Volunteer, VolunteerDecorator], id: Volunteer.available_for(user.cached_organisation_group.id).pluck(:id)
-      can :manage, [Volunteer, VolunteerDecorator], id: Volunteer.exclusive_for(user.cached_organisation_group.id).pluck(:id)
+      can %i[read download], [Volunteer, VolunteerDecorator], id: Volunteer.available_for(user.organisation_group.id).pluck(:id)
+      can :manage, [Volunteer, VolunteerDecorator], id: Volunteer.exclusive_for(user.organisation_group.id).pluck(:id)
       cannot %i[read], Volunteer, confirmed_at: nil
 
       can :update, [Address, AddressDecorator], Address.all do |address|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,7 +6,7 @@ class Ability
   include Abilities::Coordinator
 
   def initialize(user)
-    add_coordinator_ability user if user.coordinator?
-    add_super_admin_ability user if user.admin?
+    add_coordinator_ability user if user.cached_coordinator?
+    add_super_admin_ability user if user.cached_admin?
   end
 end

--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -3,6 +3,10 @@
 module Authorizable
   include ActiveSupport::Concern
 
+  def has_any_role?(role_name)
+    roles_name.include? role_name.to_s
+  end
+
   def admin?
     has_any_role? :super_admin
   end

--- a/app/models/concerns/cacheable.rb
+++ b/app/models/concerns/cacheable.rb
@@ -1,0 +1,25 @@
+module Cacheable
+  include ActiveSupport::Concern
+
+  CACHE_TIMEOUT = 5 # minutes
+  CACHED_METHOD_PREFIX = 'cached_'.freeze
+
+  def cache_output(key, expires_in: nil)
+    Rails.cache.fetch "#{cache_key_with_version}::#{key}", expires_in: (expires_in || CACHE_TIMEOUT).minutes do
+      yield self
+    end
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    method_name.to_s.start_with?(CACHED_METHOD_PREFIX) || super
+  end
+
+  private
+
+  def method_missing(m, *args)
+    method_name = m.to_s.split(CACHED_METHOD_PREFIX).last
+    return super unless method_name.present? && respond_to?(method_name)
+
+    cache_output(method_name) { send method_name.to_sym, *args }
+  end
+end

--- a/app/models/organisation_group.rb
+++ b/app/models/organisation_group.rb
@@ -8,4 +8,15 @@ class OrganisationGroup < ApplicationRecord
 
   # Validations
   validates :organisation, uniqueness: { scope: :group }
+
+  # Callbacks
+  after_commit :invalidate_coordinators_cache
+
+  private
+
+  def invalidate_coordinators_cache
+    group.organisations.each do |organisation|
+      User.with_role(:coordinator, organisation).each &:touch
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  include Authorizable
   rolify
+  include Authorizable
+  include Cacheable
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
@@ -25,10 +26,6 @@ class User < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
 
-  def cached_roles_name
-    @cached_roles_name ||= roles_name.map(&:to_sym)
-  end
-
   def organisation_colleagues
     coordinating_organisations.map(&:coordinators).flatten.uniq
   end
@@ -40,10 +37,6 @@ class User < ApplicationRecord
 
   def organisation_group
     @organisation_group ||= coordinating_groups.take
-  end
-
-  def has_any_role?(role_name)
-    cached_roles_name.include? role_name
   end
 
   def coordinators_in_organisations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  rolify
+  rolify after_add: :handle_new_role
   include Authorizable
   include Cacheable
 
@@ -56,5 +56,11 @@ class User < ApplicationRecord
 
   def coordinator_organisation_requests
     Request.where(organisation_id: coordinating_organisations.select(:id))
+  end
+
+  private
+
+  def handle_new_role(_role)
+    touch
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,10 +39,14 @@ class User < ApplicationRecord
     @organisation_group ||= coordinating_groups.take
   end
 
-  def coordinators_in_organisations
+  def group_coordinators
     User.joins(:roles).where(roles: { name: :coordinator,
                                       resource_type: :Organisation,
                                       resource_id: coordinating_organisation_ids })
+  end
+
+  def organisation_coordinators
+    User.with_role(:coordinator, organisation_group)
   end
 
   def group_volunteers

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store, { size: 64.megabytes }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
With this PR I feel like I partially failed with design.

Initial goal was 
---
- implement proper rails scopes for user
- cache cancancan ability as we use block ability definition only in one place, thus is could be (quite) easily removed

Problems
---
- I have to admin that I was not able to figure out how to write scope for e.g.
```
def coordinators_in_organisations
    User.joins(:roles).where(roles: { name: :coordinator,
                                      resource_type: :Organisation,
                                      resource_id: coordinating_organisation_ids })
  end
```
- ActiveAdmin itself injects abilities defined with block, so this was an unexpected for me

Solution
---
- implement `Cacheable` concern, which can be easily reused in other AR models than `User` only. This solution is universal, but not as elegant as I would like to see

Closes https://github.com/Applifting/pomuzeme.si/issues/228
Closes https://github.com/Applifting/pomuzeme.si/issues/162