### PR TITLE
turn on recaptcha verification

### DIFF
--- a/app/views/home/modals/_confirmation.html.erb
+++ b/app/views/home/modals/_confirmation.html.erb
@@ -25,6 +25,7 @@
         </p>
 
         <%= form.submit 'Dokončit registraci', class: 'form-button', data: { disable_with: "Dokončit registraci..." } %>
+        <%= recaptcha_v3(action: 'confirmation') %>
       <% end %>
     </section>
   </div>

--- a/app/views/volunteer/confirm_error.js.erb
+++ b/app/views/volunteer/confirm_error.js.erb
@@ -1,7 +1,10 @@
 var confirmationErrors = $('#confirmation-errors-list');
 
+// reset reCaptcha token
+executeRecaptchaForConfirmation();
 // clear old errors
 confirmationErrors.empty();
+
 <% if defined? error %>
   confirmationErrors.append('<li><%= error %></li>')
 <% else %>

--- a/app/views/volunteer/confirm_success.js.erb
+++ b/app/views/volunteer/confirm_success.js.erb
@@ -2,6 +2,8 @@ var confirmationModal = M.Modal.getInstance(document.getElementById('confirmatio
 var confirmationErrors = $('#confirmation-errors-list');
 var thankYouModal = M.Modal.getInstance(document.getElementById('thank-you'));
 
+// reset reCaptcha token
+executeRecaptchaForConfirmation();
 // clear old errors
 confirmationErrors.empty();
 
@@ -16,6 +18,7 @@ $('#volunteer_email').val('')
 $('#volunteer_street').val('')
 $('#volunteer_city').val('')
 $('#volunteer_zipcode').val('')
+$('#volunteer_street_search').val('')
 $('#volunteer_terms_of_service').prop('checked', false)
 $('#volunteer_age_confirmed').prop('checked', false)
 

--- a/app/views/volunteer/register_error.js.erb
+++ b/app/views/volunteer/register_error.js.erb
@@ -1,6 +1,8 @@
 var registrationModal = $('#registration');
 var registrationErrors = $('#registration-errors-list');
 
+// reset reCaptcha token
+executeRecaptchaForLogin();
 // clear old errors
 registrationErrors.empty();
 

--- a/app/views/volunteer/register_success.js.erb
+++ b/app/views/volunteer/register_success.js.erb
@@ -2,7 +2,9 @@ var registrationModal = M.Modal.getInstance(document.getElementById('registratio
 var registrationErrors = $('#registration-errors-list');
 var confirmationModal = M.Modal.getInstance(document.getElementById('confirmation'));
 
-
+// reset reCaptcha token
+executeRecaptchaForLogin();
+executeRecaptchaForConfirmation();
 // clear old errors
 registrationErrors.empty();
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,20 @@
 require_relative 'boot'
 
-require 'rails/all'
+%w[
+  active_record/railtie
+  active_storage/engine
+  action_controller/railtie
+  action_view/railtie
+  action_mailer/railtie
+  active_job/railtie
+  rails/test_unit/railtie
+  sprockets/railtie
+].each do |railtie|
+  begin
+    require railtie
+  rescue LoadError
+  end
+end
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
Turn on recaptcha verification
On each ajax call, regenerate recaptcha token. This was problem in initial implementations, as we couldn't use same token for multiple verifications.

Turn off autoloading of some rails components, as I was getting `uninitialized constant ActionText::Engine::ApplicationController (NameError)` in local environment.
https://stackoverflow.com/questions/59011353/rails-6-uninitialized-constant-actiontextengineapplicationcontroller-namee
https://github.com/rails/rails/issues/36963
Also it can reduce memory consumption for a little bit

closes https://github.com/Applifting/pomuzeme.si/issues/97