### PR TITLE
do not accumulate receiver jobs

### DIFF
--- a/app/jobs/messages/receiver_job.rb
+++ b/app/jobs/messages/receiver_job.rb
@@ -7,7 +7,7 @@ module Messages
     rescue StandardError => e
       Raven.capture_exception e
     ensure
-      Messages::ReceiverJob.perform_later
+      Messages::ReceiverJob.perform_later unless already_performing? || already_enqueued?
     end
 
     def perform
@@ -17,7 +17,21 @@ module Messages
         SmsService.receive
       else
         puts 'Calling receiver service'
+        sleep 10
       end
+    end
+
+    private
+
+    def already_performing?
+      Sidekiq::Workers.new.to_a.any? do |worker|
+        data = worker.try :[], 2 # data are third element of worker array
+        (data&.dig('payload', 'queue') == 'receiver_queue') && (data&.dig('payload', 'jid') != provider_job_id)
+      end
+    end
+
+    def already_enqueued?
+      Sidekiq::ScheduledSet.new.scan("Messages::ReceiverJob").any?
     end
   end
 end


### PR DESCRIPTION
This modification prevents running more than one `Messages::ReceiverJob`. In case job is invoked from some external resource, it is performed and then ensures there is only one job instance scheduled/performing.