### PR TITLE
fix receiver reenqueue

### DIFF
--- a/app/jobs/messages/receiver_job.rb
+++ b/app/jobs/messages/receiver_job.rb
@@ -2,18 +2,31 @@ module Messages
   class ReceiverJob < ApplicationJob
     queue_as :receiver_queue
 
+    REPEAT_COUNT = 30
+    TIMEOUT = 30 # seconds
+
     around_perform do |job, block|
       block.call
     rescue StandardError => e
       Raven.capture_exception e
     ensure
-      # wait 6 seconds due to update of workers information
-      Messages::ReceiverJob.set(wait: 6.seconds).perform_later unless already_performing? || already_enqueued?
+      Messages::ReceiverJob.perform_later unless already_performing? || already_enqueued?
     end
 
     def perform
       Rails.logger.debug 'Performing MessageReceiverJob'
+      start_time = Time.current
 
+      counter = 0
+      while (counter < REPEAT_COUNT) || ((Time.current - start_time) < TIMEOUT.seconds)
+        counter += 1
+        receive_sms
+      end
+    end
+
+    private
+
+    def receive_sms
       if Rails.env.production? || ENV['RECEIVE_MESSAGES'] == 'true'
         SmsService.receive
       else
@@ -21,8 +34,6 @@ module Messages
         sleep 10
       end
     end
-
-    private
 
     def already_performing?
       Sidekiq::Workers.new.to_a.any? do |worker|

--- a/app/jobs/messages/receiver_job.rb
+++ b/app/jobs/messages/receiver_job.rb
@@ -7,7 +7,8 @@ module Messages
     rescue StandardError => e
       Raven.capture_exception e
     ensure
-      Messages::ReceiverJob.perform_later unless already_performing? || already_enqueued?
+      # wait 6 seconds due to update of workers information
+      Messages::ReceiverJob.set(wait: 6.seconds).perform_later unless already_performing? || already_enqueued?
     end
 
     def perform


### PR DESCRIPTION
Allow ReceiverJob to
- handle at least `REPEAT_COUNT`
- run at least `TIMEOUT` seconds

I've added second condition in case that `REPEAT_COUNT` would be processed faster than 5 seconds (which is refresh time of `Sidekiq::Workers` stats).