### PR TITLE
Fix/notify after update

### DIFF
--- a/app/admin/requested_volunteers.rb
+++ b/app/admin/requested_volunteers.rb
@@ -15,8 +15,10 @@ ActiveAdmin.register RequestedVolunteer do
 
     def update
       super do |success, failure|
-        notify_volunteers_updated if success.present? && should_notify_update?
-        success.html { redirect_to admin_organisation_request_path(resource.request_id) }
+        success.html do
+          notify_volunteers_updated if should_notify_update?
+          redirect_to admin_organisation_request_path(resource.request_id)
+        end
         failure.html { render :new }
       end
     end

--- a/app/admin/requested_volunteers.rb
+++ b/app/admin/requested_volunteers.rb
@@ -15,6 +15,7 @@ ActiveAdmin.register RequestedVolunteer do
 
     def update
       super do |success, failure|
+        notify_volunteers_updated if success.present? && should_notify_update?
         success.html { redirect_to admin_organisation_request_path(resource.request_id) }
         failure.html { render :new }
       end
@@ -25,6 +26,17 @@ ActiveAdmin.register RequestedVolunteer do
         success.html { redirect_to admin_organisation_request_path(resource.request_id) }
         failure.html { render :new }
       end
+    end
+
+    private
+
+    def notify_volunteers_updated
+      Admin::Requests::VolunteerNotifier.new(current_user, resource.request).notify_updated
+    end
+
+    # send update only in case volunteer is has accepted request and sensitive information is visible
+    def should_notify_update?
+      resource.accepted? && resource.visible_sensitive?
     end
   end
 end

--- a/app/admin/requested_volunteers.rb
+++ b/app/admin/requested_volunteers.rb
@@ -15,10 +15,8 @@ ActiveAdmin.register RequestedVolunteer do
 
     def update
       super do |success, failure|
-        success.html do
-          notify_volunteers_updated if should_notify_update?
-          redirect_to admin_organisation_request_path(resource.request_id)
-        end
+        notify_volunteers_updated if success.present? && should_notify_update?
+        success.html { redirect_to admin_organisation_request_path(resource.request_id) }
         failure.html { render :new }
       end
     end

--- a/app/admin/requested_volunteers.rb
+++ b/app/admin/requested_volunteers.rb
@@ -31,7 +31,7 @@ ActiveAdmin.register RequestedVolunteer do
     private
 
     def notify_volunteers_updated
-      Admin::Requests::VolunteerNotifier.new(current_user, resource.request).notify_updated
+      Admin::Requests::VolunteerNotifier.new(current_user, resource.request, resource).notify_updated
     end
 
     # send update only in case volunteer is has accepted request and sensitive information is visible


### PR DESCRIPTION
@landovsky I have to rollback proposed changes from https://github.com/Applifting/pomuzeme.si/pull/268 . As I see now, it is not possible to handle notification logic inside `success.html` block, because we use ajax actions in active admin. So previous implementation works