### PR TITLE
Fix AddDefaultFlagToAddress migration

### DIFF
--- a/db/migrate/20200331095042_add_default_flag_to_address.rb
+++ b/db/migrate/20200331095042_add_default_flag_to_address.rb
@@ -6,7 +6,9 @@ class AddDefaultFlagToAddress < ActiveRecord::Migration[6.0]
 
     reversible do |dir|
       dir.up do
-        Address.update_all default: true
+        Address.where('addresses.id IN (SELECT MAX(addresses.id) from addresses GROUP BY addressable_id)')
+               .order('addresses.created_at DESC')
+               .update_all(default: true)
       end
     end
 


### PR DESCRIPTION
Fixes migration bug in production:
```
PG::UniqueViolation: ERROR:  could not create unique index "addresses_only_one_default"
DETAIL:  Key (addressable_id, addressable_type, "default")=(1054, Volunteer, t) is duplicated.
```