### PR TITLE
Make volunteer's email nullable

### DIFF
--- a/db/migrate/20200616073106_change_email_in_volunteers.rb
+++ b/db/migrate/20200616073106_change_email_in_volunteers.rb
@@ -1,0 +1,5 @@
+class ChangeEmailInVolunteers < ActiveRecord::Migration[6.0]
+  def change
+    change_column :volunteers, :email, :string, null: true
+  end
+end


### PR DESCRIPTION
Email is not a mandatory field. Currently, when email is not provided, empty string is stored instead of `null`.

This change makes email address nullable, and converts all empty emails to nulls.