### PR TITLE
Volunteer signup exclusivity option for organisation group

### DIFF
--- a/app/admin/groups.rb
+++ b/app/admin/groups.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Group do
-  permit_params :name, :slug, :channel_description, :thank_you
+  decorate_with GroupDecorator
+
+  permit_params :name, :slug, :channel_description, :thank_you, :exclusive_volunteer_signup
 
   index do
     para 'Organizační skupina zastřešuje vaše místní organizace, které mezi sebou sdílí dobrovolníky.'
-    para 'Do skupiny jsou napojeni dobrovolníci, kteří se zaregistrovali přes link vaší organizace (např. pomuzeme.si/clovek-v-tisni).'
+    para 'Do skupiny jsou napojeni dobrovolníci, kteří se zaregistrovali přes link vaší organizace (např. pomuzeme.si/diecezni-charita-ceske-budejovice).'
 
     id_column
     column :name
@@ -22,6 +24,7 @@ ActiveAdmin.register Group do
       attributes_table_for resource do
         row :name
         row :slug
+        row :exclusive_volunteer_signup
         row :created_at
         row :updated_at
       end

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -93,7 +93,7 @@ class VolunteersController < ApplicationController
   end
 
   def bind_volunteer_with_organisation_group(volunteer)
-    @partner_signup_group.add_exclusive_volunteer(volunteer)
+    @partner_signup_group.add_group_volunteer(volunteer)
   end
 
   def agreements_granted?(volunteer)

--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -1,0 +1,8 @@
+class GroupDecorator < ApplicationDecorator
+  delegate_all
+
+  def slug
+    url = "https://pomuzeme.si/#{object.slug}"
+    h.link_to url, url, target: '_blank'
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -10,9 +10,9 @@ class Group < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
 
-  def add_exclusive_volunteer(volunteer)
+  def add_group_volunteer(volunteer)
     GroupVolunteer.create group: self,
-                          is_exclusive: true,
+                          is_exclusive: exclusive_volunteer_signup,
                           volunteer: volunteer,
                           recruitment_status: GroupVolunteer::DEFAULT_RECRUITMENT_STATUS,
                           source: GroupVolunteer.sources[:channel]

--- a/app/views/home/modals/_thank_you.html.erb
+++ b/app/views/home/modals/_thank_you.html.erb
@@ -14,7 +14,7 @@
         <p>Nyní na vás mají kontakt dobročinné organizace z&nbsp;vašeho blízkého okolí. Mějte trpělivost a některá z&nbsp;nich se vám ozve.</p>
       <% end %>
       <a href="<%= volunteer_profile_path %>" class="main-button secondary">
-        POKRAČOVAT NA PROFIL
+        UPŘESNIT PREFERENCE
       </a>
 
       <p class="social-text">Můžete pomoct i tím, že iniciativu budete sdílet!</p>

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -94,8 +94,10 @@ cs:
         updated_at: Upraven
       group:
         name: Název
-        slug: Kód
-        channel_description: Krátký popis na web
+        slug: Adresa registračního formuláře
+        channel_description: Krátký popis na registrační formulář
+        exclusive_volunteer_signup: Exklusivita přihlášených dobrovolníků
+        thank_you: Děkovný text po registraci
         created_at: Vytvořeno
         updated_at: Upraveno
       group_volunteer:

--- a/db/migrate/20201021113201_add_exclusive_volunteers_flag_to_groups.rb
+++ b/db/migrate/20201021113201_add_exclusive_volunteers_flag_to_groups.rb
@@ -1,0 +1,6 @@
+class AddExclusiveVolunteersFlagToGroups < ActiveRecord::Migration[6.0]
+  def change
+    # Indicates if volunteer sign-ed up through group url is exclusive or not
+    add_column :groups, :exclusive_volunteer_signup, :boolean, default: true
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -20,16 +20,31 @@ RSpec.describe Group, type: :model do
     it { should have_many(:volunteers) }
   end
 
-  context '#add_exclusive_volunteer' do
-    let(:group) { create :group }
+  context '#add_group_volunteer' do
     let(:volunteer) { create :volunteer }
 
-    it 'should assign volunteer exclusively to group' do
-      group_volunteer = group.add_exclusive_volunteer volunteer
-      expect(group_volunteer.is_exclusive).to be true
-      expect(group_volunteer.group).to eq group
-      expect(GroupVolunteer.sources[group_volunteer.source]).to eq GroupVolunteer.sources[:channel]
-      expect(GroupVolunteer.recruitment_statuses[group_volunteer.recruitment_status]).to eq GroupVolunteer::DEFAULT_RECRUITMENT_STATUS
+    context 'when volunteers signed up through organisation form are to be exclusive' do
+      let(:group) { create :group, exclusive_volunteer_signup: true }
+
+      it 'should assign volunteer exclusively to group' do
+        group_volunteer = group.add_group_volunteer volunteer
+        expect(group_volunteer.is_exclusive).to be true
+        expect(group_volunteer.group).to eq group
+        expect(GroupVolunteer.sources[group_volunteer.source]).to eq GroupVolunteer.sources[:channel]
+        expect(GroupVolunteer.recruitment_statuses[group_volunteer.recruitment_status]).to eq GroupVolunteer::DEFAULT_RECRUITMENT_STATUS
+      end
+    end
+
+    context 'when volunteers signed up through organisation form are to be public' do
+      let(:group) { create :group, exclusive_volunteer_signup: false }
+
+      it 'should assign volunteer to group, but volunteers remains public' do
+        group_volunteer = group.add_group_volunteer volunteer
+        expect(group_volunteer.is_exclusive).to be false
+        expect(group_volunteer.group).to eq group
+        expect(GroupVolunteer.sources[group_volunteer.source]).to eq GroupVolunteer.sources[:channel]
+        expect(GroupVolunteer.recruitment_statuses[group_volunteer.recruitment_status]).to eq GroupVolunteer::DEFAULT_RECRUITMENT_STATUS
+      end
     end
   end
 end


### PR DESCRIPTION
Added add_exclusive_volunteer option to org group settings to make it possible for a volunteer to remain public after he signed up to an organisation.