### PR TITLE
Unread messages upgrade and bug fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ end
 group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
+  gem 'execjs'
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'

--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ end
 group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
-  gem 'execjs'
+  gem 'therubyracer'
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,7 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
+    libv8 (3.16.14.19)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -319,6 +320,7 @@ GEM
     recaptcha (5.5.0)
       json
     redis (4.1.3)
+    ref (2.0.0)
     regexp_parser (1.7.0)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -410,6 +412,9 @@ GEM
       sprockets (>= 3.0.0)
     statsd-ruby (1.4.0)
     test-prof (0.11.3)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -469,7 +474,6 @@ DEPENDENCIES
   devise
   devise-i18n
   draper
-  execjs
   factory_bot_rails (~> 5.1)
   ffaker (~> 2.14)
   geocoder
@@ -503,6 +507,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   sprockets (= 3.7.2)
   test-prof (~> 0.10)
+  therubyracer
   turbolinks (~> 5)
   tzinfo-data
   validates_zipcode

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,6 +469,7 @@ DEPENDENCIES
   devise
   devise-i18n
   draper
+  execjs
   factory_bot_rails (~> 5.1)
   ffaker (~> 2.14)
   geocoder

--- a/app/admin/messages.rb
+++ b/app/admin/messages.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register Message do
 
   form do |f|
     # Mark incoming messages as read
-    Message.incoming.unread.for_request(params[:request_id], params[:volunteer_id]).update_all(read_at: Time.zone.now)
+    Message.incoming.unread.for_request(params[:request_id], params[:volunteer_id]).each { |m| m.update(read_at: Time.zone.now) }
 
     groupped_messages = Message.for_request(params[:request_id], params[:volunteer_id])
                                .eager_load(:creator)

--- a/app/admin/messages.rb
+++ b/app/admin/messages.rb
@@ -17,9 +17,10 @@ ActiveAdmin.register Message do
 
   form do |f|
     # Mark incoming messages as read
-    Message.incoming.unread.for_request(params[:request_id], params[:volunteer_id]).each { |m| m.update(read_at: Time.zone.now) }
+    Message.mark_read(request_id: params[:request_id], volunteer_id: params[:volunteer_id])
 
-    groupped_messages = Message.for_request(params[:request_id], params[:volunteer_id])
+
+    groupped_messages = Message.with_request(params[:request_id], params[:volunteer_id])
                                .eager_load(:creator)
                                .order(:created_at)
                                .decorate.group_by { |msg| msg.created_at.to_date }

--- a/app/admin/requests.rb
+++ b/app/admin/requests.rb
@@ -19,7 +19,6 @@ ActiveAdmin.register Request, as: 'OrganisationRequest' do
   filter :organisation, as: :select, collection: proc { Organisation.user_group_organisations(current_user) }
 
   # Scopes
-  # Experimental feature
   scope :request_unread_msgs do |scope|
     scope.not_closed.has_unread_messages
   end
@@ -70,6 +69,9 @@ ActiveAdmin.register Request, as: 'OrganisationRequest' do
     column :text
     column :accepted_volunteers_count do |resource|
       "#{resource.requested_volunteers.accepted.count} / #{resource.required_volunteer_count}"
+    end
+    column :requested_volunteers do |resource|
+      resource.requested_volunteers.count
     end
     column :address
     column :fullfillment_date

--- a/app/admin/volunteers.rb
+++ b/app/admin/volunteers.rb
@@ -38,7 +38,10 @@ ActiveAdmin.register Volunteer do
 
   batch_action :assign_request, confirm: I18n.t('active_admin.batch_actions.assign_request.confirmation') do |ids|
     request = referer_request
-    Admin::Requests::VolunteerAssigner.new(current_user, request, Volunteer.where(id: ids)).perform
+    results = Admin::Requests::VolunteerAssigner.new(current_user, request, Volunteer.where(id: ids)).perform
+
+    flash[:notice] = "Počet přiřazených dobrovolníků: #{ids.count - results.count}"
+    flash[:error] = "Některé dobrovolníky se nepodařilo k poptávce přiřadit (#{results.map { |v| v.to_s }.join(', ')})." if results.present?
     redirect_to admin_organisation_request_path request.id
   rescue StandardError => e
     redirect_to admin_organisation_request_path(request.id), alert: e.message

--- a/app/assets/stylesheets/admin/form.scss
+++ b/app/assets/stylesheets/admin/form.scss
@@ -27,4 +27,11 @@ textarea {
     background-color: green;
     color: white;
   }
+
+  &.secondary {
+    background-color: white;
+    color: green;
+    border: 1px solid green;
+    border-radius: 4px;
+  }
 }

--- a/app/jobs/messages/received_processor_job.rb
+++ b/app/jobs/messages/received_processor_job.rb
@@ -13,7 +13,7 @@ module Messages
 
         Common::Request::ResponseProcessor.new(request, requested_volunteer.volunteer, response).perform
         confirm_response
-        mark_message_as_read
+        mark_message_as_read if rejection_response?
       rescue Common::Request::CapacityExceededError
         capacity_exceeded_response
       end
@@ -23,6 +23,10 @@ module Messages
 
     def valid_response?
       !response.nil?
+    end
+
+    def rejection_response?
+      response == false
     end
 
     def invalid_response

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,10 +1,10 @@
 class Message < ApplicationRecord
-  # Callbacks
-  MESSAGES_FOR_REQUEST_SQL = 'volunteer_id = %{volunteer_id} AND (request_id IS NULL OR request_id = %{request_id})'.freeze
+  MESSAGES_WITH_REQUEST_SQL = 'volunteer_id = %{volunteer_id} AND (request_id IS NULL OR request_id = %{request_id})'.freeze
 
-  after_create  :update_counter_cache
-  after_destroy :update_counter_cache
-  after_update  :update_counter_cache
+  # Callbacks
+  after_create  :update_unread_messages_counter_cache
+  after_destroy :update_unread_messages_counter_cache
+  after_update  :update_unread_messages_counter_cache
 
   # Associations
   belongs_to :volunteer, optional: true
@@ -22,19 +22,36 @@ class Message < ApplicationRecord
 
   # Scopes
   scope :unread, -> { where(read_at: nil) }
-  scope :for_request, ->(request_id, volunteer_id) { where(format(MESSAGES_FOR_REQUEST_SQL, request_id: request_id, volunteer_id: volunteer_id)) }
+  scope :with_request, ->(request_id, volunteer_id) { where(format(MESSAGES_WITH_REQUEST_SQL, request_id: request_id, volunteer_id: volunteer_id)) }
 
   def mark_as_read
     update read_at: Time.zone.now if read_at.nil?
   end
 
+  def read?
+    read_at.present?
+  end
+
+  def self.mark_read(request_id:, volunteer_id:)
+    Message.incoming.unread.with_request(:request_id, :volunteer_id).each do |message|
+      message.update(read_at: Time.zone.now)
+    end
+  end
+
+  def self.update_unread_messages_counter_cache(volunteer_id:, request_id:)
+    # Incoming SMS cannot be matched with specific request, hence optional request_id
+    # when such message is received, all matching requested volunteers' cache is updated
+    # so that all requests with this volunteer is flagged as unread
+    requested_volunteers = RequestedVolunteer.with_optional_request_id(volunteer_id, request_id)
+
+    requested_volunteers.each do |requested_volunteer|
+      requested_volunteer.update(unread_incoming_messages_count: requested_volunteer.unread_incoming_messages.count)
+    end
+  end
+
   private
 
-  def update_counter_cache
-    return if volunteer_id.blank? || request_id.blank?
-
-    requested_volunteer = RequestedVolunteer.where(volunteer_id: volunteer_id, request_id: request_id).first
-
-    requested_volunteer.update(unread_incoming_messages_count: requested_volunteer.unread_incoming_messages.count)
+  def update_unread_messages_counter_cache
+    Message.update_unread_messages_counter_cache(volunteer_id: volunteer_id, request_id: request_id)
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -50,6 +50,7 @@ class Request < ApplicationRecord
   scope :check_fulfillment, -> { where('state = 4 AND fullfillment_date < ?', Time.zone.now) }
   scope :without_coordinator, -> { where(coordinator_id: nil) }
   scope :has_unread_messages, -> { joins(:requested_volunteers).where('requested_volunteers.unread_incoming_messages_count > 0').distinct }
+  scope :not_closed, -> { where.not(state: :closed) }
 
   def title
     [text[0..39], address].compact.join ', '

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -49,7 +49,7 @@ class Request < ApplicationRecord
   scope :in_progress, -> { where('state = 4 AND (fullfillment_date IS NULL OR fullfillment_date > ?)', Time.zone.now) }
   scope :check_fulfillment, -> { where('state = 4 AND fullfillment_date < ?', Time.zone.now) }
   scope :without_coordinator, -> { where(coordinator_id: nil) }
-  scope :has_unread_messages, -> { joins(requested_volunteers: :messages).merge(Message.incoming.unread).distinct }
+  scope :has_unread_messages, -> { joins(:requested_volunteers).where('requested_volunteers.unread_incoming_messages_count > 0').distinct }
 
   def title
     [text[0..39], address].compact.join ', '

--- a/app/services/admin/requests/volunteer_assigner.rb
+++ b/app/services/admin/requests/volunteer_assigner.rb
@@ -12,10 +12,24 @@ module Admin
       end
 
       def perform
+        @failed_volunteers = []
+
         RequestedVolunteer.transaction do
           @volunteers.available_for(@user.organisation_group.id).each do |volunteer|
-            RequestedVolunteer.create! volunteer: volunteer, request: @request, state: @requested_state
+            assign_volunteer_to_request(volunteer)
           end
+        end
+
+        @failed_volunteers
+      end
+
+      def assign_volunteer_to_request(volunteer)
+        begin
+          RequestedVolunteer.create! volunteer: volunteer, request: @request, state: @requested_state
+        rescue ActiveRecord::RecordInvalid => e
+          @failed_volunteers << volunteer
+          Raven.extra_context(volunteer_id: volunteer.id, request_id: @request, user_id: @user.id, user_full_name: @user.to_s)
+          Raven.capture_exception e
         end
       end
     end

--- a/app/views/admin/organisation_requests/_volunteers.html.arb
+++ b/app/views/admin/organisation_requests/_volunteers.html.arb
@@ -9,9 +9,20 @@ if can?(:manage, Request) && resource.requested_volunteers.to_be_notified.presen
   span(link_to('Oslovit dobrovolníky', notify_volunteers_admin_organisation_request_path, method: :post, class: 'button primary'))
 end
 
-table_for resource.requested_volunteers.includes(:volunteer).order(:state).map(&:decorate) do
+table_for resource.requested_volunteers.includes(volunteer: :group_volunteers).order(:state).map(&:decorate) do
   column I18n.t('activerecord.attributes.volunteer.full_name'), :full_name, &:volunteer_name_link
   column I18n.t('activerecord.attributes.volunteer.phone'), :phone
+  column I18n.t('activerecord.attributes.group_volunteer.source') do |resource|
+    source = resource.volunteer.group_volunteers&.first&.source || :public_pool
+    I18n.t("activerecord.enums.group_volunteer.source." + source.to_s)
+  end
+  column I18n.t('activerecord.attributes.group_volunteer.recruitment_status') do |resource|
+    status = resource.volunteer
+                     .group_volunteers
+                     .find { |gv| gv.group_id == current_user.organisation_group.id }
+                    &.recruitment_status
+    I18n.t("activerecord.enums.group_volunteer.recruitment_statuses." + status.to_s) if status
+  end
   column I18n.t('activerecord.attributes.requested_volunteer.state') do |requested_volunteer|
     best_in_place requested_volunteer, :state, as: :select,
                                                collection: I18n.t('activerecord.attributes.requested_volunteer.states'),

--- a/app/views/admin/organisation_requests/_volunteers.html.arb
+++ b/app/views/admin/organisation_requests/_volunteers.html.arb
@@ -25,7 +25,7 @@ table_for resource.requested_volunteers.includes(:volunteer).order(:state).map(&
                                                            url: admin_organisation_request_requested_volunteer_path(resource, requested_volunteer)
   end
   column '' do |requested_volunteer|
-    link_title = requested_volunteer.messages.incoming.unread.present? ? 'nepřečtené zprávy' : 'zprávy'
+    link_title = requested_volunteer.unread_incoming_messages_count.positive? ? 'nepřečtené zprávy' : 'zprávy'
     link_to link_title, new_admin_volunteer_message_path(requested_volunteer.volunteer_id, request_id: resource.id)
   end
 end

--- a/app/views/admin/organisation_requests/_volunteers.html.arb
+++ b/app/views/admin/organisation_requests/_volunteers.html.arb
@@ -5,11 +5,13 @@ div class: 'title h4' do
   span link_to('', admin_volunteers_path(params: resource.decorate.volunteer_params), class: 'action add', data: { turbolinks: false }) if can?(:manage, Request)
 end
 
-if can?(:manage, Request) && resource.requested_volunteers.to_be_notified.present?
-  span(link_to('Oslovit dobrovolníky', notify_volunteers_admin_organisation_request_path, method: :post, class: 'button primary'))
+div style: 'margin-bottom: 8px;' do
+  if can?(:manage, Request) && resource.requested_volunteers.to_be_notified.present?
+    span(link_to('Oslovit dobrovolníky', notify_volunteers_admin_organisation_request_path, method: :post, class: 'button secondary'))
+  end
 end
 
-table_for resource.requested_volunteers.includes(volunteer: :group_volunteers).order(:state).map(&:decorate) do
+table_for resource.requested_volunteers.includes(volunteer: :group_volunteers).order([{ unread_incoming_messages_count: :desc }, :state]).map(&:decorate) do
   column I18n.t('activerecord.attributes.volunteer.full_name'), :full_name, &:volunteer_name_link
   column I18n.t('activerecord.attributes.volunteer.phone'), :phone
   column I18n.t('activerecord.attributes.group_volunteer.source') do |resource|

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -290,7 +290,7 @@ cs:
       offer: "%{identifier} %{text} Prosíme, odpovězte ANO / NE"
       unrecognized: Máte-li o poptávku zájem, odpovězte ANO nebo NE
       confirmed: Díky za potvrzení poptávky %{identifier}, koordinátor %{organisation} se vám ozve s detaily.
-      rejected: Poptávka %{identifier} organizace %{organisation} byla odmítnuta.
+      rejected: Poptávka %{identifier} organizace %{organisation} byla odmítnuta. Své dobrovolnické preference můžete nastavit na https://pomuzeme.si/profil?utm_medium=sms
       over_capacity: Moc děkujeme za zájem, na poptávku organizace %{organisation} se již našlo dostatek dobrovolníků. Počkejte na další.
   volunteer_profile:
     login:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -176,6 +176,7 @@ cs:
         organisation: Organizace
         required_volunteer_count: Požadovaný počet dobrovolníků
         accepted_volunteers_count: Potvrzení / požadovaní dobrovolníci
+        requested_volunteers: Oslovení dobrovolníci
         state: Stav
         state_last_updated_at: Stav naposledy aktualizován
         subscriber: Příjemce

--- a/db/migrate/20201021145736_add_unread_messages_count_to_requested_volunteers.rb
+++ b/db/migrate/20201021145736_add_unread_messages_count_to_requested_volunteers.rb
@@ -1,0 +1,11 @@
+class AddUnreadMessagesCountToRequestedVolunteers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :requested_volunteers, :unread_incoming_messages_count, :integer, null: false, default: 0
+
+    reversible do |dir|
+      dir.up do
+        RequestedVolunteer.all.each { |rv| rv.update unread_incoming_messages_count: rv.unread_incoming_messages.count }
+      end
+    end
+  end
+end

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -10,7 +10,8 @@ FactoryBot.define do
 
     trait :with_group do
       transient do
-        group { create :group }
+        slug { 'slug' }
+        group { create :group, slug: slug }
       end
 
       after(:create) do |organisation, evaluator|

--- a/spec/features/volunteer_messages_spec.rb
+++ b/spec/features/volunteer_messages_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Volunteer Messages' do
       it 'requested volunteer has "unread messages" tag' do
         visit admin_organisation_request_path(request)
 
-        expect(page).to have_text 'Petr Long +420777111222 Odesílání zprávy - nepřečtené zprávy'
+        expect(page).to have_text 'Petr Long +420777111222 veřejný seznam Odesílání zprávy - nepřečtené zprávy'
       end
     end
   end

--- a/spec/features/volunteer_messages_spec.rb
+++ b/spec/features/volunteer_messages_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+require 'support/messaging_service_helper'
+
+RSpec.feature 'Volunteer Messages' do
+  include MessagingServiceHelper
+
+  let(:organisation) { create :organisation, :with_group }
+  let(:user) { create :user, :with_organisation_group, organisation: organisation }
+  let(:request) { create :request, state: :searching_capacity, organisation: organisation, text: 'Help in hospital' }
+  let(:volunteer) { create :volunteer, first_name: 'Petr', last_name: 'Long', phone: '+420777111222' }
+  let!(:requested_volunteer) { create :requested_volunteer, request: request, volunteer: volunteer }
+  let(:incoming_message) { ->(text = ano) { MessagingService::Callbacks.message_received mock_message_response(number: volunteer.phone, text: text) } }
+
+  before :each do
+    login_as user
+    incoming_message['Im not sure']
+  end
+
+  context 'when system received new new (incoming) message from requested volunteer' do
+    feature 'to an opened request' do
+
+      it 'the request list shows unread scope count' do
+        visit admin_organisation_requests_path(scope: :request_unread_msgs)
+
+        expect(page).to have_text I18n.t('active_admin.scopes.request_unread_msgs') + ' (1)'
+        expect(page).to have_text 'Help in hospital'
+      end
+    end
+
+    feature 'to a closed request' do
+      let!(:request) { create :request, state: :closed, organisation: organisation, text: 'Help in hospital' }
+
+      it 'the request list shows 0 unread count' do
+        visit admin_organisation_requests_path
+
+        expect(page).to have_text I18n.t('active_admin.scopes.request_unread_msgs') + ' (0)'
+      end
+    end
+
+    feature 'in the request detail' do
+      it 'requested volunteer has "unread messages" tag' do
+        visit admin_organisation_request_path(request)
+
+        expect(page).to have_text 'Petr Long +420777111222 Odesílání zprávy - nepřečtené zprávy'
+      end
+    end
+  end
+
+  context 'when user visits requested volunteers messages with unread messages' do
+    it 'marks unread messages as read' do
+      expect(requested_volunteer.reload.unread_incoming_messages_count).to eq 1
+
+      visit new_admin_volunteer_message_path(volunteer.id, request_id: request.id)
+
+      expect(page).to have_text 'Im not sure'
+      expect(requested_volunteer.reload.unread_incoming_messages_count).to eq 0
+    end
+
+    it 'recalculates unread_incoming_messages_count of all requested volunteers matched by volunteer_id' do
+      group2        = create :group, name: 'Some other group'
+      organisation2 = create :organisation, name: 'Some other org'
+      create :organisation_group, organisation: organisation2, group: group2
+      request2      = create :request, state: :searching_capacity, organisation: organisation2, text: 'Help in school'
+      requested_volunteer2 = create :requested_volunteer, request: request2, volunteer: volunteer
+
+      incoming_message['another message']
+
+      expect(requested_volunteer.reload.unread_incoming_messages_count).to eq 2
+      expect(requested_volunteer2.reload.unread_incoming_messages_count).to eq 2
+
+      visit new_admin_volunteer_message_path(volunteer.id, request_id: request.id)
+
+      expect(requested_volunteer.reload.unread_incoming_messages_count).to eq 0
+      expect(requested_volunteer2.reload.unread_incoming_messages_count).to eq 0
+    end
+  end
+end

--- a/spec/jobs/messages_received_processor_job_spec.rb
+++ b/spec/jobs/messages_received_processor_job_spec.rb
@@ -21,13 +21,31 @@ describe Messages::ReceivedProcessorJob do
           Messages::ReceivedProcessorJob.new.perform message[volunteer, 'ano']
         end
 
-        it 'marks incoming message as read' do
-          incoming_msg = message[volunteer, 'ano']
+        it 'marks incoming rejection message as read' do
+          incoming_msg = message[volunteer, 'ne']
           expect(incoming_msg.read_at).to be_nil
 
           Messages::ReceivedProcessorJob.new.perform incoming_msg
 
           expect(incoming_msg.read_at).not_to be_nil
+        end
+
+        it 'leaves incoming acceptance message unread' do
+          incoming_msg = message[volunteer, 'ano']
+          expect(incoming_msg.read_at).to be_nil
+
+          Messages::ReceivedProcessorJob.new.perform incoming_msg
+
+          expect(incoming_msg.read_at).to be_nil
+        end
+
+        it 'leaves other incoming message unread' do
+          incoming_msg = message[volunteer, 'nevim']
+          expect(incoming_msg.read_at).to be_nil
+
+          Messages::ReceivedProcessorJob.new.perform incoming_msg
+
+          expect(incoming_msg.read_at).to be_nil
         end
 
         it 'creates acceptance confirmation msg when offer is accepted' do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Message, type: :model do
       end
     end
 
-    context '.for_request' do
+    context '.with_request' do
       let(:volunteer) { create :volunteer }
       let(:another_volunteer) { create :volunteer }
       let!(:request) { create :request }
@@ -44,22 +44,22 @@ RSpec.describe Message, type: :model do
       let!(:message) { create :message, volunteer: volunteer }
 
       it 'returns messages with matching volunteer id and no request id' do
-        expect(Message.for_request(request.id, volunteer.id)).to include(message)
+        expect(Message.with_request(request.id, volunteer.id)).to include(message)
       end
 
       it 'returns messages with matching volunteer id and request id' do
         message.update! request: request
-        expect(Message.for_request(request.id, volunteer.id)).to include(message)
+        expect(Message.with_request(request.id, volunteer.id)).to include(message)
       end
 
       it 'does not return messages with matching volunteer id and different request id' do
         message.update! request: another_request
-        expect(Message.for_request(request.id, volunteer.id)).not_to include(message)
+        expect(Message.with_request(request.id, volunteer.id)).not_to include(message)
       end
 
       it 'does not return messages with different volunteer id and matching request id' do
         message.update! volunteer: another_volunteer, request: request
-        expect(Message.for_request(request.id, volunteer.id)).not_to include(message)
+        expect(Message.with_request(request.id, volunteer.id)).not_to include(message)
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,5 @@
 ENV['RAILS_ENV'] ||= 'test'
+ENV['SMS_MOCK'] ||= 'true'
 
 require 'simplecov'
 SimpleCov.start 'rails' do
@@ -35,8 +36,19 @@ Shoulda::Matchers.configure do |config|
 end
 
 RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+  config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :view
+  config.include Warden::Test::Helpers
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.before(:all) do
+    I18n.locale = :cs
   end
 
   config.mock_with :rspec do |mocks|
@@ -60,7 +72,4 @@ RSpec.configure do |config|
   I18n.enforce_available_locales = false
   I18n.locale = :en
 
-  config.include ActiveSupport::Testing::TimeHelpers
-  config.include FactoryBot::Syntax::Methods
-  config.include ActiveSupport::Testing::TimeHelpers
 end


### PR DESCRIPTION
- caching unread_incoming_messages_count
- refactored and fixed marking messages as read
- only declination messages are automatically marked as read
- added additional volunteer data to list of volunteers in request
- added flash message for successful unsuccessful addition of volunteer to request (+ logging of unsucessful) 