### PR TITLE
Fixed unread messages and closed requests

### DIFF
--- a/app/services/common/request/response_processor.rb
+++ b/app/services/common/request/response_processor.rb
@@ -15,7 +15,9 @@ module Common
           validate_capacity!
           requested_volunteer.update!(state: request_accepted? ? :accepted : :rejected)
           request.update! state: resolve_request_state
-          log_response_message
+
+          # This probably should be higher up in the chain so that we don't need to treat the 'if' exception
+          log_response_message if volunteer.push_notifications?
         end
       end
 
@@ -46,7 +48,7 @@ module Common
         Message.create! volunteer: volunteer,
                         request: request,
                         text: message_text,
-                        direction: :incoming,
+                        direction: :outgoing,
                         state: :received
       end
 

--- a/app/views/home/modals/_thank_you.html.erb
+++ b/app/views/home/modals/_thank_you.html.erb
@@ -20,13 +20,13 @@
       <p class="social-text">Můžete pomoct i tím, že iniciativu budete sdílet!</p>
 
       <div class="social-sites">
-        <a class="site" href="https://www.facebook.com/sharer/sharer.php?u=pomuzemesi.cz" target="_blank">
+        <a class="site" href="https://www.facebook.com/sharer/sharer.php?u=pomuzemesi.cz" id='cta-social-share-fb' target="_blank">
           <div class="circle">
             <%= image_tag asset_path('social-facebook.svg')  %>
           </div>
           <div class="label">Facebook</div>
         </a>
-        <a class="site" href="http://twitter.com/share?url=https://pomuzemesi.cz" target="_blank">
+        <a class="site" href="http://twitter.com/share?url=https://pomuzemesi.cz" id='cta-social-share-twitter' target="_blank">
           <div class="circle">
             <%= image_tag asset_path('social-twitter.svg')  %>
           </div>

--- a/spec/services/common/request/response_processor_spec.rb
+++ b/spec/services/common/request/response_processor_spec.rb
@@ -15,14 +15,16 @@ describe Common::Request::ResponseProcessor do
         .to raise_error(AuthorisationError)
     end
 
-    context 'when user accepts' do
-      it 'logs accepting response status as message to request' do
+    context 'when volunteer with push notifications accepts' do
+      it 'logs accepting response status as message to request (to have a record in the Messages)' do
+        volunteer.update preferences: { notifications_to_app: true }
+
         expect(Message).to receive(:create!).with(volunteer: volunteer,
                                                   request: request,
                                                   text: I18n.t('request.responses.accept'),
-                                                  direction: :incoming,
+                                                  direction: :outgoing,
                                                   state: :received)
-        Common::Request::ResponseProcessor.new(request, volunteer, true).perform
+        Common::Request::ResponseProcessor.new(request, volunteer.reload, true).perform
       end
 
       it 'changes request state if capacity is filled' do
@@ -53,12 +55,14 @@ describe Common::Request::ResponseProcessor do
       end
     end
 
-    context 'when user rejects' do
+    context 'when user with push notifications rejects' do
       it 'logs rejecting response status as message to request' do
+        volunteer.update preferences: { notifications_to_app: true }
+
         expect(Message).to receive(:create!).with(volunteer: volunteer,
                                                   request: request,
                                                   text: I18n.t('request.responses.rejected'),
-                                                  direction: :incoming,
+                                                  direction: :outgoing,
                                                   state: :received)
         Common::Request::ResponseProcessor.new(request, volunteer, false).perform
       end


### PR DESCRIPTION
Bugs:
- incoming message changes state of closed request
- incoming declination SMS message causes log_response_message when this method call is needed just for API acceptance / rejection