### PR TITLE
Forward accepted volunteer to subscriber organisation (#310)

### DIFF
--- a/app/admin/requests.rb
+++ b/app/admin/requests.rb
@@ -93,7 +93,7 @@ ActiveAdmin.register Request, as: 'OrganisationRequest' do
         if can?(:manage, resource)
           attributes_table_for resource do
             row :subscriber
-            row :subscriber_phone
+            row :subscriber_phone_and_messages
             row :subscriber_email
             row :long_text
           end
@@ -143,7 +143,7 @@ ActiveAdmin.register Request, as: 'OrganisationRequest' do
     f.semantic_errors
 
     f.inputs 'Poptávka služby' do
-      f.input :text, as: :text, hint: 'Tento popis dostane dobrovolník do aplikace / SMS', input_html: { class: :character_counter, 'data-limit' => 160 }
+      f.input :text, as: :text, hint: 'Tento popis dostane dobrovolník do aplikace / SMS.', input_html: { class: :character_counter, 'data-limit' => 160 }
       f.input :required_volunteer_count, input_html: { value: object.required_volunteer_count.nil? ? 1 : resource.required_volunteer_count }
       f.input :fullfillment_date, as: :date_time_picker, input_html: { autocomplete: 'off' }
     end
@@ -152,7 +152,8 @@ ActiveAdmin.register Request, as: 'OrganisationRequest' do
       para 'K osobním údajům příjemce služby se dostanou pouze koordinátoři vaší organizace.', class: :small
       f.input :subscriber
       f.input :subscriber_organisation
-      f.input :subscriber_phone, input_html: { maxlength: 13 }
+      f.input :subscriber_phone, input_html: { maxlength: 13 },
+                                 hint: 'Je-li příjemce organizace, dostane po přijetí poptávky dobrovolníkem automaticky SMS s jeho kontaktem.'
       f.input :subscriber_email, input_html: { maxlength: 64 }
       address_label = proc { |type| I18n.t("activerecord.attributes.request.#{type}") }
       custom_input :full_address, class: 'geocomplete',

--- a/app/admin/subscriber_messages.rb
+++ b/app/admin/subscriber_messages.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register Message, as: 'Subscriber Message' do
+  permit_params :request_id, :created_by_id, :text, :channel, :message_type
+
+  controller do
+    def create
+      # Potentional vulnerability due to trusting permitted_params values
+      MessagingService.create_message permitted_params[:message]
+      redirect_to new_admin_subscriber_message_path(request_id: params[:message][:request_id],
+                                                    subscriber_phone: params[:message][:phone]), notice: 'Zpráva odeslána'
+    rescue StandardError => e
+      redirect_to new_admin_subscriber_message_path(request_id: params[:message][:request_id],
+                                                    subscriber_phone: params[:message][:phone]), alert: e.message
+    end
+  end
+
+  form do |f|
+    # Mark incoming messages as read
+    volunteer_request = Request.find(params[:request_id])
+    volunteer_request.subscriber_messages.incoming.unread.each { |message| message.update read_at: Time.zone.now }
+
+    groupped_messages = volunteer_request.subscriber_messages
+                                         .eager_load(:creator)
+                                         .order(:created_at)
+                                         .decorate.group_by { |msg| msg.created_at.to_date }
+
+    panel 'Konverzace s příjemcem' do
+      render partial: 'admin/messages/messages', locals: { groupped_messages: groupped_messages }
+    end
+
+    f.inputs 'Nová zpráva' do
+      f.input :text
+      f.input :request_id, as: :hidden, input_html: { value: params[:request_id] }
+      f.input :created_by_id, as: :hidden, input_html: { value: current_user.id }
+      f.input :channel, as: :hidden, input_html: { value: :sms }
+      f.input :message_type, as: :hidden, input_html: { value: :subscriber }
+      f.input :phone, as: :hidden, input_html: { value: params[:subscriber_phone] }
+      custom_input :redirect_to, type: :hidden, value: request.referrer
+    end
+    f.actions do
+      f.action :submit
+      f.action :cancel, as: :link, label: 'Zpět do poptávky', url: admin_organisation_request_path(params[:request_id])
+    end
+  end
+end

--- a/app/decorators/request_decorator.rb
+++ b/app/decorators/request_decorator.rb
@@ -14,6 +14,16 @@ class RequestDecorator < ApplicationDecorator
     end
   end
 
+  def subscriber_phone_and_messages
+    unread_incoming = subscriber_messages.unread.incoming.count
+    link_text = unread_incoming.positive? ? 'nepřečetené zprávy' : 'zprávy'
+
+    content = []
+    content << object.subscriber_phone
+    content << h.link_to(link_text, h.new_admin_subscriber_message_path(request_id: id, subscriber_phone: object.subscriber_phone))
+    content.join(' | ').html_safe
+  end
+
   def public_subscriber
     object.subscriber_organisation.presence || I18n.t('activerecord.attributes.request.subscriber_hidden')
   end

--- a/app/jobs/messages/received_processor_job.rb
+++ b/app/jobs/messages/received_processor_job.rb
@@ -15,7 +15,7 @@ module Messages
         # Don't process messages for closed requests
         next if @request.closed?
 
-        request_parsable_response && next unless valid_response?
+        send_request_not_parsable_response && next unless valid_response?
 
         Common::Request::ResponseProcessor.new(request, requested_volunteer.volunteer, response).perform
         confirm_response
@@ -36,7 +36,7 @@ module Messages
       response == false
     end
 
-    def request_parsable_response
+    def send_request_not_parsable_response
       volunteer = Volunteer.find(message.volunteer_id)
       text      = I18n.t('sms.request.unrecognized')
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,5 +1,5 @@
 class Message < ApplicationRecord
-  MESSAGES_WITH_REQUEST_SQL = 'volunteer_id = %{volunteer_id} AND (request_id IS NULL OR request_id = %{request_id})'.freeze
+  VOLUNTEER_MESSAGES_WITH_REQUEST_SQL = 'volunteer_id = %{volunteer_id} AND (request_id IS NULL OR request_id = %{request_id})'.freeze
 
   # Callbacks
   after_create  :update_unread_messages_counter_cache
@@ -15,14 +15,19 @@ class Message < ApplicationRecord
   enum state: { pending: 1, sent: 2, received: 3 }
   enum direction: { outgoing: 1, incoming: 2 }
   enum channel: { sms: 1, push: 2 }
-  enum message_type: { other: 1, request_offer: 2, request_update: 3 }, _prefix: true
+  enum message_type: { other: 1, request_offer: 2, request_update: 3, subscriber: 4 }, _prefix: true
+
+  phony_normalize :phone, default_country_code: 'CZ'
+  phony_normalized_method :phone, default_country_code: 'CZ'
 
   # Validations
   validates_presence_of :text
 
   # Scopes
   scope :unread, -> { where(read_at: nil) }
-  scope :with_request, ->(request_id, volunteer_id) { where(format(MESSAGES_WITH_REQUEST_SQL, request_id: request_id, volunteer_id: volunteer_id)) }
+  scope :with_request_and_volunteer, ->(request_id:, volunteer_id:) do
+    where(format(VOLUNTEER_MESSAGES_WITH_REQUEST_SQL, request_id: request_id, volunteer_id: volunteer_id))
+  end
 
   def mark_as_read
     update read_at: Time.zone.now if read_at.nil?
@@ -33,7 +38,7 @@ class Message < ApplicationRecord
   end
 
   def self.mark_read(request_id:, volunteer_id:)
-    Message.incoming.unread.with_request(:request_id, :volunteer_id).each do |message|
+    Message.incoming.unread.with_request_and_volunteer(request_id: request_id, volunteer_id: volunteer_id).each do |message|
       message.update(read_at: Time.zone.now)
     end
   end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -78,6 +78,11 @@ class Request < ApplicationRecord
     @identifier ||= [organisation.abbreviation, ('%04d' % id)].join '-'
   end
 
+  def subscriber_messages
+    @subscriber_messages = Message.joins('LEFT JOIN requests r ON r.id = messages.request_id OR r.subscriber_phone = messages.phone')
+                                  .where(messages: { message_type: :subscriber }).where('r.id = ?', id)
+  end
+
   private
 
   def address_presence

--- a/app/services/common/request/response_processor.rb
+++ b/app/services/common/request/response_processor.rb
@@ -18,6 +18,7 @@ module Common
 
           # This probably should be higher up in the chain so that we don't need to treat the 'if' exception
           log_response_message if volunteer.push_notifications?
+          notify_subscriber_organisation_about_acceptance if request_accepted?
         end
       end
 
@@ -35,6 +36,15 @@ module Common
         return @request_accepted if defined? @request_accepted
 
         @request_accepted = ActiveModel::Type::Boolean.new.cast is_accepted
+      end
+
+      def notify_subscriber_organisation_about_acceptance
+        return if request.subscriber_organisation.blank?
+
+        text = I18n.t 'sms.request.subscriber_notification', identifier: request.identifier,
+                                                             full_name: volunteer.to_s,
+                                                             phone: volunteer.phone
+        SmsService.send_text request.subscriber_phone, text
       end
 
       def resolve_request_state

--- a/app/views/admin/messages/_messages.html.arb
+++ b/app/views/admin/messages/_messages.html.arb
@@ -1,25 +1,23 @@
-panel 'Konverzace s dobrovolníkem' do
-  div class: :conversation do
-    para 'Žádné zprávy.' if groupped_messages.blank?
+div class: :conversation do
+  para 'Žádné zprávy.' if groupped_messages.blank?
 
-    groupped_messages.each do |date, messages|
-      ul class: 'messages' do
-        li date, class: 'date-header'
-        messages.each do |msg|
-          li class: msg.sent_by_css('msg') do
-            div class: 'msg-wrapper' do
-              div class: 'msg-box' do
-                div msg.text, class: 'body'
-                div id: 'msg-time', style: 'display: inline-flex' do
-                  seen_date = msg&.read_at
-                  div(span, class: 'unread-dot') unless seen_date
-                  span [msg.creator.to_s, msg.created_at.strftime('%H:%M')].compact.join(' '), class: 'msg-time'
-                  span "| #{Message.human_attribute_name(:channel)}: #{msg.channel}", class: 'msg-channel' if msg.channel.present?
-                  if seen_date
-                    div("přečteno před #{distance_of_time_in_words(seen_date, Time.zone.now)}",
-                        class: 'msg-time tooltip',
-                        title: seen_date)
-                  end
+  groupped_messages.each do |date, messages|
+    ul class: 'messages' do
+      li date, class: 'date-header'
+      messages.each do |msg|
+        li class: msg.sent_by_css('msg') do
+          div class: 'msg-wrapper' do
+            div class: 'msg-box' do
+              div msg.text, class: 'body'
+              div id: 'msg-time', style: 'display: inline-flex' do
+                seen_date = msg&.read_at
+                div(span, class: 'unread-dot') if seen_date.nil? && msg.incoming?
+                span [msg.creator.to_s, msg.created_at.strftime('%H:%M')].compact.join(' '), class: 'msg-time'
+                span "| #{Message.human_attribute_name(:channel)}: #{msg.channel}", class: 'msg-channel' if msg.channel.present?
+                if seen_date
+                  div("přečteno před #{distance_of_time_in_words(seen_date, Time.zone.now)}",
+                      class: 'msg-time tooltip',
+                      title: seen_date)
                 end
               end
             end

--- a/app/views/admin/organisation_requests/_volunteers.html.arb
+++ b/app/views/admin/organisation_requests/_volunteers.html.arb
@@ -39,6 +39,6 @@ table_for resource.requested_volunteers.includes(volunteer: :group_volunteers).o
   end
   column '' do |requested_volunteer|
     link_title = requested_volunteer.unread_incoming_messages_count.positive? ? 'nepřečtené zprávy' : 'zprávy'
-    link_to link_title, new_admin_volunteer_message_path(requested_volunteer.volunteer_id, request_id: resource.id)
+    link_to link_title, new_admin_message_path(volunteer_id: requested_volunteer.volunteer_id, request_id: resource.id)
   end
 end

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -186,6 +186,7 @@ cs:
         subscriber_hidden: Příjemce je jednotlivec
         subscriber_organisation: Organizace příjemce
         subscriber_phone: Telefon příjemce
+        subscriber_phone_and_messages: Telefon příjemce
         subscriber_email: Email příjemce
         created_at: Vytvořeno
         states:
@@ -289,13 +290,14 @@ cs:
     verification: "Overovaci kod pro overeni registrace na portalu pomuzeme.si je: %{code}"
     mobile_authorization: "Overovaci kod pro prihlaseni do aplikace pomuzeme.si je: %{code}"
     welcome: Vitejte mezi dobrovolniky! Mame vas v databazi, brzy se ozve jedna z organizaci ve vasem okoli a zapoji vas do deni. Reknete o nas i pratelum? Pomuzeme.si
-    welcome_channel: Vitejte mezi dobrovolniky! Mame vas v databazi, brzy se vám ozve %{group_name} a zapoji vas do deni. Reknete o nas i pratelum? pomuzeme.si/%{group_slug}
+    welcome_channel: Vitejte mezi dobrovolniky! Na pomuzeme.si/prilezitosti najdete aktuální seznam žádostí o pomoc. Na pomuzeme.si/profil si nastavíte své preference (zájmy).
     request:
       offer: "%{identifier} %{text} Prosíme, odpovězte ANO / NE"
       unrecognized: Máte-li o poptávku zájem, odpovězte ANO nebo NE
       confirmed: Díky za potvrzení poptávky %{identifier}, koordinátor %{organisation} se vám ozve s detaily.
       rejected: Poptávka %{identifier} organizace %{organisation} byla odmítnuta. Své dobrovolnické preference můžete nastavit na https://pomuzeme.si/profil?utm_medium=sms
       over_capacity: Moc děkujeme za zájem, na poptávku organizace %{organisation} se již našlo dostatek dobrovolníků. Počkejte na další.
+      subscriber_notification: Na vaší poptávku %{identifier} se přihlásil nový dobrovolník - %{full_name}, %{phone}.
   volunteer_profile:
     login:
       title: Přihlášení do profilu

--- a/db/migrate/20201027202744_add_phone_to_messages.rb
+++ b/db/migrate/20201027202744_add_phone_to_messages.rb
@@ -1,0 +1,5 @@
+class AddPhoneToMessages < ActiveRecord::Migration[6.0]
+  def change
+    add_column :messages, :phone, :string, index: true
+  end
+end

--- a/spec/factories/request.rb
+++ b/spec/factories/request.rb
@@ -14,5 +14,9 @@ FactoryBot.define do
     after(:build) do |request|
       request.address = build(:address, addressable: request)
     end
+
+    trait :from_organisation do
+      subscriber_organisation { 'Člověk v tísni' }
+    end
   end
 end

--- a/spec/features/volunteer_messages_spec.rb
+++ b/spec/features/volunteer_messages_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature 'Volunteer Messages' do
     it 'marks unread messages as read' do
       expect(requested_volunteer.reload.unread_incoming_messages_count).to eq 1
 
-      visit new_admin_volunteer_message_path(volunteer.id, request_id: request.id)
+      visit new_admin_message_path(volunteer_id: volunteer.id, request_id: request.id)
 
       expect(page).to have_text 'Im not sure'
       expect(requested_volunteer.reload.unread_incoming_messages_count).to eq 0
@@ -68,7 +68,7 @@ RSpec.feature 'Volunteer Messages' do
       expect(requested_volunteer.reload.unread_incoming_messages_count).to eq 2
       expect(requested_volunteer2.reload.unread_incoming_messages_count).to eq 2
 
-      visit new_admin_volunteer_message_path(volunteer.id, request_id: request.id)
+      visit new_admin_message_path(volunteer_id: volunteer.id, request_id: request.id)
 
       expect(requested_volunteer.reload.unread_incoming_messages_count).to eq 0
       expect(requested_volunteer2.reload.unread_incoming_messages_count).to eq 0

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Message, type: :model do
     it { should define_enum_for(:state).with_values(pending: 1, sent: 2, received: 3) }
     it { should define_enum_for(:direction).with_values(outgoing: 1, incoming: 2) }
     it { should define_enum_for(:channel).with_values(sms: 1, push: 2) }
-    it { should define_enum_for(:message_type).with_values(other: 1, request_offer: 2, request_update: 3).with_prefix(:message_type) }
+    it { should define_enum_for(:message_type).with_values(other: 1, request_offer: 2, request_update: 3, subscriber: 4).with_prefix(:message_type) }
   end
 
   context 'scopes' do
@@ -36,7 +36,7 @@ RSpec.describe Message, type: :model do
       end
     end
 
-    context '.with_request' do
+    context '.with_request_and_volunteer' do
       let(:volunteer) { create :volunteer }
       let(:another_volunteer) { create :volunteer }
       let!(:request) { create :request }
@@ -44,22 +44,22 @@ RSpec.describe Message, type: :model do
       let!(:message) { create :message, volunteer: volunteer }
 
       it 'returns messages with matching volunteer id and no request id' do
-        expect(Message.with_request(request.id, volunteer.id)).to include(message)
+        expect(Message.with_request_and_volunteer(request_id: request.id, volunteer_id: volunteer.id)).to include(message)
       end
 
       it 'returns messages with matching volunteer id and request id' do
         message.update! request: request
-        expect(Message.with_request(request.id, volunteer.id)).to include(message)
+        expect(Message.with_request_and_volunteer(request_id: request.id, volunteer_id: volunteer.id)).to include(message)
       end
 
       it 'does not return messages with matching volunteer id and different request id' do
         message.update! request: another_request
-        expect(Message.with_request(request.id, volunteer.id)).not_to include(message)
+        expect(Message.with_request_and_volunteer(request_id: request.id, volunteer_id: volunteer.id)).not_to include(message)
       end
 
       it 'does not return messages with different volunteer id and matching request id' do
         message.update! volunteer: another_volunteer, request: request
-        expect(Message.with_request(request.id, volunteer.id)).not_to include(message)
+        expect(Message.with_request_and_volunteer(request_id: request.id, volunteer_id: volunteer.id)).not_to include(message)
       end
     end
   end


### PR DESCRIPTION
* Removed message nesting under volunteer

* Save subscribers incoming texts

* SMS chat with subscriber

* forward accepted volunteers to organisation subscriber

* process incoming message only if volunteer is found