### PR TITLE
Fixes for subscriber messaging (#312)

### DIFF
--- a/app/services/common/request/response_processor.rb
+++ b/app/services/common/request/response_processor.rb
@@ -44,7 +44,15 @@ module Common
         text = I18n.t 'sms.request.subscriber_notification', identifier: request.identifier,
                                                              full_name: volunteer.to_s,
                                                              phone: volunteer.phone
-        SmsService.send_text request.subscriber_phone, text
+
+        message = Message.create! text: text,
+                                  direction: :outgoing,
+                                  channel: :sms,
+                                  message_type: :subscriber,
+                                  phone: request.subscriber_phone,
+                                  request: request
+
+        Messages::SenderJob.perform_later message.id
       end
 
       def resolve_request_state

--- a/app/services/messaging_service/callbacks.rb
+++ b/app/services/messaging_service/callbacks.rb
@@ -29,7 +29,7 @@ module MessagingService
         volunteer = Volunteer.find_by(phone: adapter_response.from_number)
         requests  = Request.where(subscriber_phone: adapter_response.from_number).pluck(:id) if volunteer.blank?
 
-        return unless volunteer || requests.present?
+        return true unless volunteer || requests.present?
 
         message = Message.create! volunteer: volunteer,
                                   phone: adapter_response.from_number,
@@ -40,6 +40,7 @@ module MessagingService
                                   channel: :sms
 
         Messages::ReceivedProcessorJob.perform_later(message) if volunteer
+        true
       end
     end
   end

--- a/app/views/admin/messages/_messages.html.arb
+++ b/app/views/admin/messages/_messages.html.arb
@@ -11,7 +11,7 @@ div class: :conversation do
               div msg.text, class: 'body'
               div id: 'msg-time', style: 'display: inline-flex' do
                 seen_date = msg&.read_at
-                div(span, class: 'unread-dot') if seen_date.nil? && msg.incoming?
+                div(span, class: 'unread-dot') if seen_date.nil?
                 span [msg.creator.to_s, msg.created_at.strftime('%H:%M')].compact.join(' '), class: 'msg-time'
                 span "| #{Message.human_attribute_name(:channel)}: #{msg.channel}", class: 'msg-channel' if msg.channel.present?
                 if seen_date

--- a/spec/services/common/request/response_processor_spec.rb
+++ b/spec/services/common/request/response_processor_spec.rb
@@ -21,21 +21,21 @@ describe Common::Request::ResponseProcessor do
       let!(:requested_volunteer) { create :requested_volunteer, request: request, volunteer: volunteer }
 
       context 'when volunteer accepts request from with subscriber - organisation' do
-        it 'sends request subscriber' do
-          text = format 'Na vaší poptávku %{identifier} se přihlásil nový dobrovolník - %{full_name}, %{phone}.', identifier: request.identifier,
+        it 'sends voluteer contact to request subscriber' do
+          text = format 'Na vaší poptávku %{identifier} se přihlásil nový dobrovolník - %{full_name}, %{phone}.',
+                  identifier: request.identifier,
                   full_name: volunteer.to_s,
                   phone: volunteer.phone
-          expect(SmsService).to receive(:send_text).with '+420777222444', text
+
+          expect(Message).to receive(:create!).with(request: request,
+                                                    text: text,
+                                                    direction: :outgoing,
+                                                    message_type: :subscriber,
+                                                    channel: :sms,
+                                                    phone: '+420777222444')
+                                              .and_return(Message.new)
 
           Common::Request::ResponseProcessor.new(request, volunteer, true).perform
-        end
-      end
-
-      context 'when volunteer accepts request from with subscriber - private individual' do
-        it 'does not send request subscriber' do
-          expect(SmsService).not_to receive(:send_text)
-
-          Common::Request::ResponseProcessor.new(request, volunteer, false).perform
         end
       end
     end


### PR DESCRIPTION
* Fix for unconfirmed O2 messages

* Log receiving and confirming messages

* Bring back read-status for outgoing messages in chat

* Save subscriber notification