### PR TITLE
Allow signup of existing user to group

### DIFF
--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -8,6 +8,8 @@ class PublicController < ApplicationController
 
   def load_current_volunteer
     @current_volunteer = Volunteer.find(session[:volunteer_id]) if session[:volunteer_id]
+  rescue ActiveRecord::RecordNotFound
+    redirect_to logout_path
   end
 
   def set_raven_context

--- a/app/models/concerns/sms_confirmable.rb
+++ b/app/models/concerns/sms_confirmable.rb
@@ -17,7 +17,6 @@ module SmsConfirmable
   end
 
   def confirm_with(sms_confirmation_code)
-    return errors.add(:confirmation_code, :confirmed) if confirmed?
     return errors.add(:confirmation_code, :not_matching) if sms_confirmation_code != confirmation_code
     return errors.add(:confirmation_code, :expired) if Time.now > confirmation_valid_to
 
@@ -36,7 +35,6 @@ module SmsConfirmable
   end
 
   def obtain_confirmation_code
-    raise StandardError, 'Token already generated' unless confirmed_at.nil?
     raise StandardError, 'Token regenerated too early' unless can_obtain_code?
 
     regenerate_confirmation_code!

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -10,11 +10,15 @@ class Group < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
 
-  def add_group_volunteer(volunteer)
-    GroupVolunteer.create group: self,
-                          is_exclusive: exclusive_volunteer_signup,
-                          volunteer: volunteer,
-                          recruitment_status: GroupVolunteer::DEFAULT_RECRUITMENT_STATUS,
-                          source: GroupVolunteer.sources[:channel]
+  def build_group_volunteer(volunteer)
+    raise TypeError unless volunteer.is_a? Volunteer
+
+    exclusive_volunteer = volunteer.new_record? && exclusive_volunteer_signup
+
+    GroupVolunteer.new group: self,
+                       is_exclusive: exclusive_volunteer,
+                       volunteer: volunteer,
+                       recruitment_status: GroupVolunteer::DEFAULT_RECRUITMENT_STATUS,
+                       source: GroupVolunteer.sources[:channel]
   end
 end

--- a/app/models/group_volunteer.rb
+++ b/app/models/group_volunteer.rb
@@ -25,4 +25,5 @@ class GroupVolunteer < ApplicationRecord
   scope :in_progress, -> { where(recruitment_status: IN_RECRUITMENT) }
   scope :closed, -> { where.not(recruitment_status: IN_RECRUITMENT) }
   scope :unassigned, -> { where(coordinator_id: nil) }
+  scope :exclusive, -> { where is_exclusive: true }
 end

--- a/app/views/admin/volunteers/_requests.html.arb
+++ b/app/views/admin/volunteers/_requests.html.arb
@@ -9,8 +9,8 @@ table_for RequestedVolunteer.joins(:request)
                             .includes(:request)
                             .merge(resource.requested_volunteers.with_organisations(current_user.coordinating_organisations.pluck(:id)))
                             .decorate do
-  column(I18n.t('activerecord.attributes.request.subscriber')) { |rv| rv.request.subscriber }
-  column(I18n.t('activerecord.attributes.request.text')) { |rv| rv.request.text }
+  column(I18n.t('activerecord.attributes.request.subscriber')) { |rv| rv.reload.request.subscriber }
+  column(I18n.t('activerecord.attributes.request.text')) { |rv| rv.reload.request.text }
   column(I18n.t('activerecord.attributes.requested_volunteer.note')) { |rv| rv.note }
   column :state
   column 'Detail', class: 'centered' do |requested_volunteer|

--- a/app/views/volunteer/register_error.js.erb
+++ b/app/views/volunteer/register_error.js.erb
@@ -5,8 +5,7 @@ var registrationErrors = $('#registration-errors-list');
 registrationErrors.empty();
 
 // add new volunteer errors
-<% volunteer.errors.delete :addresses %>
-<% volunteer.errors.full_messages.each do |message| %>
+<% volunteer.errors.messages[:base]&.each do |message| %>
   registrationErrors.append('<li><%= message %></li>')
 <% end %>
 

--- a/db/migrate/20201210103031_add_public_flag_to_volunteer.rb
+++ b/db/migrate/20201210103031_add_public_flag_to_volunteer.rb
@@ -1,0 +1,11 @@
+class AddPublicFlagToVolunteer < ActiveRecord::Migration[6.0]
+  def change
+    add_column :volunteers, :is_public, :boolean, null: true, default: true
+
+    reversible do |dir|
+      dir.up do
+        Volunteer.joins(:group_volunteers).merge(GroupVolunteer.exclusive).update_all(is_public: false)
+      end
+    end
+  end
+end

--- a/spec/models/sms_confirmable_spec.rb
+++ b/spec/models/sms_confirmable_spec.rb
@@ -38,16 +38,6 @@ describe SmsConfirmable do
       end.to change(confirmable, :confirmed_at).from(nil)
     end
 
-    context 'given model is already confirmed' do
-      let(:confirmed_at) { 1.day.ago }
-
-      it 'adds error to confirmable model' do
-        confirmable.confirm_with(sms_confirmation_code)
-        expect(confirmable.errors.messages.values.flatten)
-          .to include('is already confirmed')
-      end
-    end
-
     context 'given sms code and stored code are nil' do
       let(:sms_confirmation_code) { nil }
       let(:confirmation_code) { nil }
@@ -104,16 +94,6 @@ describe SmsConfirmable do
 
     before do
       allow(SmsService).to receive(:send_text)
-    end
-
-    context 'given confirmed_at is set' do
-      let(:confirmed_at) { Time.now }
-
-      it 'raises error' do
-        expect do
-          confirmable.obtain_confirmation_code
-        end.to raise_error('Token already generated')
-      end
     end
 
     context 'given confirmed_at is not set' do


### PR DESCRIPTION
- allow repeated signup of existing volunteer to prevent situation when someone forgot sh/e already signed up
- allow sign-up of existing volunteer to organisation (Group) with proper setting of volunteer exclusivity